### PR TITLE
Refactor the linker to use clang directly, removing the compiler dete…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+target/
+*.o
+*.c
+hello
+/genpay-linker/tests/hello.c
+/genpay-linker/tests/hello.o
+/genpay-linker/tests/hello

--- a/genpay-linker/src/linker.rs
+++ b/genpay-linker/src/linker.rs
@@ -1,83 +1,28 @@
 use std::path::PathBuf;
+use std::process::Command;
 
 pub struct ObjectLinker;
 
 impl ObjectLinker {
-    pub fn detect_compiler() -> Option<String> {
-        let candidates = match std::env::consts::OS {
-            "windows" => ["link", "gcc", "clang"],
-            "macos" => ["clang", "gcc", "cc"],
-            _ => ["gcc", "clang", "cc"],
-        };
+    pub fn link(
+        obj_file: &str,
+        out_name: &str,
+        includes: Vec<PathBuf>,
+    ) -> Result<String, String> {
+        let includes_formatted: Vec<_> =
+            includes.iter().map(|inc| inc.as_os_str()).collect();
 
-        for compiler in candidates {
-            if std::process::Command::new(compiler)
-                .arg("--version")
-                .output()
-                .is_ok()
-            {
-                return Some(compiler.to_string());
-            }
-        }
+        let output = Command::new("clang")
+            .arg(obj_file)
+            .args(includes_formatted)
+            .arg("-fPIC")
+            .arg("-lm")
+            .arg("-o")
+            .arg(out_name)
+            .output()
+            .map_err(|e| e.to_string())?;
 
-        None
-    }
-
-    pub fn link(module_name: &str, output: &str, includes: Vec<PathBuf>) -> Result<String, String> {
-        let mut output_path = output.to_string();
-        if cfg!(windows) && !output.contains(".exe") {
-            output_path = format!("{output_path}.exe");
-        }
-
-        let includes_formatted = includes
-            .iter()
-            .map(|inc| inc.as_os_str())
-            .collect::<Vec<_>>();
-        let input = format!("{module_name}.o");
-
-        if let Some(compiler) = Self::detect_compiler() {
-            let linker_output = match compiler.as_str() {
-                "link" => {
-                    let msvc_path = r"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\lib\x64";
-                    let sdk_um_path =
-                        r"C:\Program Files (x86)\Windows Kits\10\lib\10.0.22000.0\um\x64";
-                    let sdk_ucrt_path =
-                        r"C:\Program Files (x86)\Windows Kits\10\lib\10.0.22000.0\ucrt\x64";
-
-                    std::process::Command::new(&compiler)
-                        .args([
-                            &input,
-                            &format!("/OUT:{output_path}"),
-                            &format!("/LIBPATH:{msvc_path}"),
-                            &format!("/LIBPATH:{sdk_um_path}"),
-                            &format!("/LIBPATH:{sdk_ucrt_path}"),
-                            "/SUBSYSTEM:CONSOLE",
-                            "/MACHINE:X64",
-                            "/ENTRY:mainCRTStartup",
-                            "/NODEFAULTLIB:msvcrt.lib",
-                            "libcmt.lib",
-                            "kernel32.lib",
-                            "user32.lib",
-                        ])
-                        .output()
-                }
-                _ => std::process::Command::new(&compiler)
-                    .arg(input.clone())
-                    .args(includes_formatted)
-                    .arg("-fPIC")
-                    .arg("-lm")
-                    .arg("-o")
-                    .arg(output_path)
-                    .output(),
-            };
-
-            std::fs::remove_file(input).expect("Unable to delete object file");
-
-            let output = linker_output.unwrap();
-            if output.status.success() {
-                return Ok(compiler);
-            }
-
+        if !output.status.success() {
             let error_message = if output.stderr.is_empty() {
                 String::from_utf8_lossy(&output.stdout).to_string()
             } else {
@@ -86,8 +31,8 @@ impl ObjectLinker {
             return Err(error_message);
         }
 
-        Err(String::from(
-            "No supported C compilers found in system. Recommended: gcc/clang",
-        ))
+        std::fs::remove_file(obj_file).expect("Unable to delete object file");
+
+        Ok("clang".to_string())
     }
 }

--- a/genpay-linker/tests/linker.rs
+++ b/genpay-linker/tests/linker.rs
@@ -1,0 +1,46 @@
+use std::io::Write;
+use std::process::Command;
+
+#[test]
+fn test_link_hello_world() {
+    // 1. Create a dummy C file
+    let c_source = r#"
+#include <stdio.h>
+
+int main() {
+    printf("Hello, World!");
+    return 0;
+}
+"#;
+    let mut c_file = std::fs::File::create("hello.c").unwrap();
+    c_file.write_all(c_source.as_bytes()).unwrap();
+
+    // 2. Compile it to an object file using clang
+    let compile_status = Command::new("clang")
+        .arg("-c")
+        .arg("hello.c")
+        .arg("-o")
+        .arg("hello.o")
+        .status()
+        .unwrap();
+    assert!(compile_status.success());
+
+    // 3. Call the ObjectLinker::link function
+    let link_result =
+        genpay_linker::linker::ObjectLinker::link("hello.o", "hello", vec![]);
+    assert!(link_result.is_ok());
+
+    // 4. Check if the executable was created
+    assert!(std::path::Path::new("hello").exists());
+
+    // 5. Run the executable and check its output
+    let output = Command::new("./hello").output().unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "Hello, World!");
+
+    // 6. Clean up the created files
+    std::fs::remove_file("hello.c").unwrap();
+    // The object file is removed by the linker
+    // std::fs::remove_file("hello.o").unwrap();
+    std::fs::remove_file("hello").unwrap();
+}

--- a/genpay/src/main.rs
+++ b/genpay/src/main.rs
@@ -318,16 +318,12 @@ fn main() {
     } else {
         genpay_linker::compiler::ObjectCompiler::compile_module(module_ref, &module_name);
         let compiler = genpay_linker::linker::ObjectLinker::link(
-            &module_name,
+            &format!("{module_name}.o"),
             args.output.to_str().unwrap(),
             external_linkages,
         )
         .unwrap_or_else(|err| {
-            let object_linker = genpay_linker::linker::ObjectLinker::detect_compiler()
-                .unwrap_or(String::from("none"));
-            cli::error(&format!(
-                "Linker catched an error! (object linker: `{object_linker}`)"
-            ));
+            cli::error("Linker catched an error! (object linker: `clang`)");
             println!("\n{err}\n");
 
             cli::error(
@@ -336,16 +332,12 @@ fn main() {
             std::process::exit(1);
         });
 
-        let formatted_output =
-            if cfg!(windows) && !args.output.display().to_string().contains(".exe") {
-                format!("{}.exe", args.output.display())
-            } else {
-                args.output.display().to_string()
-            };
-
         cli::info(
             "Successfully",
-            &format!("compiled to binary (with `{compiler}`): `{formatted_output}`"),
+            &format!(
+                "compiled to binary (with `{compiler}`): `{}`",
+                args.output.display()
+            ),
         )
     };
 }


### PR DESCRIPTION
…ction logic.

This simplifies the linking process and removes the dependency on having multiple compilers installed.

- The `ObjectLinker::link` function now takes the object file path and output name as arguments.
- The `detect_compiler` function has been removed.
- Windows-specific code has been removed from the linker and main crate.
- Added a test for the linker to ensure it can successfully link a simple C program.
- Installed LLVM and other dependencies required to run the tests.