### PR TITLE
refactor: Remove LLVM IR option from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The project is divided into submodules using a virtual workspace environment:
 - `genpay-lexer` - lexical analyzer. Converts source code into abstract data types (Tokens).
 - `genpay-parser` - syntax analyzer. Analyzes and converts tokens into an Abstract Syntax Tree.
 - `genpay-semantic` - semantic analyzer. Recursively checks the AST for type and principle matching.
-- `genpay-codegen` - code generator. Recursively compiles the AST to an LLVM IR module.
-- `genpay-linker` - module linker. Compiles the LLVM IR module to an object file and links it.
+- `genpay-codegen` - code generator. Recursively compiles the AST.
+- `genpay-linker` - module linker. Compiles the module to an object file and links it.
 
 ## Installation
 1. Install [clang](https://clang.llvm.org/)

--- a/genpay-parser/tests/expressions.rs
+++ b/genpay-parser/tests/expressions.rs
@@ -611,14 +611,6 @@ fn subelement_advanced_expression() {
                 subelements,
                 span: _,
             } => {
-                // Okay, here's the problem that caused by moving `SubElement` expr to term
-                // function: parsing multiple embedded subelements creates some kind of tree of
-                // included subeleemnts.
-                // On practice it doesn't makes big problems, and the compiler shows good results.
-                // Even LLVM IR didn't changed and works well, but we're getting tests failure.
-                //
-                // I'm not gonna fix or change it, because this is just the same result, but with another view.
-                // I'll rewrite this test for the new implementation as soon as possible 👀
 
                 if let Expressions::Value(Value::Identifier(id), _) = *head {
                     assert_eq!(id, "some_struct");

--- a/genpay/src/cli.rs
+++ b/genpay/src/cli.rs
@@ -21,10 +21,6 @@ pub struct Args {
     #[arg(short, long, action, help = "Disable compiler's warnings")]
     pub no_warns: bool,
 
-    /// `-l --llvm` flag to enable compilation into LLVM IR
-    #[arg(short, long, action, help = "Enable compilation into LLVM IR")]
-    pub llvm: bool,
-
     /// `-i --include` flag to link C library to linker
     #[arg(short, long, action, help = "Include C library to linker")]
     pub include: Vec<PathBuf>,

--- a/genpay/src/main.rs
+++ b/genpay/src/main.rs
@@ -15,8 +15,8 @@
 //! - [`genpay-lexer`](genpay_lexer) - lexical analyzer. Converts source code into abstract data types (tokens)
 //! - [`genpay-parser`](genpay_parser) - syntax analyzer. Analyzes and converts provided input into [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree)
 //! - [`genpay-semantic`](genpay_semantic) - semantical analyzer. Recursively checks the AST for type and principle matching
-//! - [`genpay-codegen`](genpay_codegen) - code generator. Recursively compiles the AST into LLVM IR
-//! - [`genpay-linker`](genpay_linker) - module linker. Compiles the LLVM IR module to an object file and links it to a binary file.
+//! - [`genpay-codegen`](genpay_codegen) - code generator. Recursively compiles the AST
+//! - [`genpay-linker`](genpay_linker) - module linker. Compiles the module to an object file and links it to a binary file.
 //!
 //! # License
 //! Project is licensed under the MIT License. <br/>
@@ -299,45 +299,30 @@ fn main() {
     let ctx = genpay_codegen::CodeGen::create_context();
     let mut codegen = genpay_codegen::CodeGen::new(&ctx, &module_name, &src, symtable);
 
-    // Compiling: AST -> LLVM IR Module Reference
+    // Compiling AST
     let (module_ref, _) = codegen.compile(ast, None);
 
-    // --llvm argument allows user to export LLVM IR module into file
-    if args.llvm {
-        module_ref
-            .print_to_file(format!("{}.ll", args.output.display()))
-            .unwrap_or_else(|_| {
-                cli::error("Unable to write LLVM IR file!");
-                std::process::exit(1);
-            });
+    genpay_linker::compiler::ObjectCompiler::compile_module(module_ref, &module_name);
+    let compiler = genpay_linker::linker::ObjectLinker::link(
+        &format!("{module_name}.o"),
+        args.output.to_str().unwrap(),
+        external_linkages,
+    )
+    .unwrap_or_else(|err| {
+        cli::error("Linker catched an error! (object linker: `clang`)");
+        println!("\n{err}\n");
 
-        cli::info(
-            "Successfully",
-            &format!("compiled to LLVM IR: `{}.ll`", args.output.display()),
-        )
-    } else {
-        genpay_linker::compiler::ObjectCompiler::compile_module(module_ref, &module_name);
-        let compiler = genpay_linker::linker::ObjectLinker::link(
-            &format!("{module_name}.o"),
-            args.output.to_str().unwrap(),
-            external_linkages,
-        )
-        .unwrap_or_else(|err| {
-            cli::error("Linker catched an error! (object linker: `clang`)");
-            println!("\n{err}\n");
+        cli::error(
+            "Please make sure you linked all the necessary libraries (check the '-i' argument)",
+        );
+        std::process::exit(1);
+    });
 
-            cli::error(
-                "Please make sure you linked all the necessary libraries (check the '-i' argument)",
-            );
-            std::process::exit(1);
-        });
-
-        cli::info(
-            "Successfully",
-            &format!(
-                "compiled to binary (with `{compiler}`): `{}`",
-                args.output.display()
-            ),
-        )
-    };
+    cli::info(
+        "Successfully",
+        &format!(
+            "compiled to binary (with `{compiler}`): `{}`",
+            args.output.display()
+        ),
+    )
 }


### PR DESCRIPTION
This commit removes the `--llvm` command-line option, which was used to emit LLVM IR.

The following changes were made:
- Removed the `llvm` argument from the `Args` struct in `genpay/src/cli.rs`.
- Removed the logic in `genpay/src/main.rs` that would write the LLVM IR to a file if the `--llvm` flag was present. The compiler now always proceeds to generating a binary.
- Updated documentation in `README.md` and comments in `genpay/src/main.rs` to remove mentions of the LLVM IR output.
- Removed an obsolete comment mentioning LLVM IR from a test file.