### PR TITLE
This commit refactors the integration test in the `genpay-linker` cra…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "genpay"
 version = "1.1.0"
 dependencies = [
@@ -257,8 +263,7 @@ dependencies = [
 name = "genpay-linker"
 version = "1.1.0"
 dependencies = [
- "inkwell",
- "llvm-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -291,7 +296,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.3+wasi-0.2.4",
 ]
 
 [[package]]
@@ -501,12 +518,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.14",
 ]
@@ -593,6 +616,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -690,6 +726,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.3+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-link"
@@ -843,3 +888,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"

--- a/genpay-linker/src/linker.rs
+++ b/genpay-linker/src/linker.rs
@@ -31,8 +31,6 @@ impl ObjectLinker {
             return Err(error_message);
         }
 
-        std::fs::remove_file(obj_file).expect("Unable to delete object file");
-
         Ok("clang".to_string())
     }
 }

--- a/genpay-linker/tests/linking.rs
+++ b/genpay-linker/tests/linking.rs
@@ -1,0 +1,50 @@
+use std::io::Write;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn test_link_hello_world() {
+    // 0. Create a temporary directory
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+
+    // 1. Create a dummy C file
+    let c_source = r#"
+#include <stdio.h>
+
+int main() {
+printf("Hello, World!");
+return 0;
+}
+"#;
+    let c_path = root.join("hello.c");
+    let mut c_file = std::fs::File::create(&c_path).unwrap();
+    c_file.write_all(c_source.as_bytes()).unwrap();
+
+    // 2. Compile it to an object file using clang
+    let o_path = root.join("hello.o");
+    let compile_status = Command::new("clang")
+        .arg("-c")
+        .arg(&c_path)
+        .arg("-o")
+        .arg(&o_path)
+        .status()
+        .unwrap();
+    assert!(compile_status.success());
+
+    // 3. Call the ObjectLinker::link function
+    let exe_path = root.join("hello");
+    let link_result =
+        genpay_linker::linker::ObjectLinker::link(o_path.to_str().unwrap(), exe_path.to_str().unwrap(), vec![]);
+    assert!(link_result.is_ok());
+
+    // 4. Check if the executable was created
+    assert!(exe_path.exists());
+
+    // 5. Run the executable and check its output
+    let output = Command::new(exe_path).output().unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "Hello, World!");
+
+    // 6. The temporary directory and its contents (including the .o file) will be automatically removed
+}


### PR DESCRIPTION
…te and improves the `ObjectLinker`.

The key changes are:
- The integration test has been moved from `src/lib.rs` to a dedicated `tests/linking.rs` file.
- The test now uses a temporary directory to avoid creating files in the project root during test execution.
- The `ObjectLinker::link` function has been improved to remove the side-effect of deleting the input object file. The caller is now responsible for managing the lifecycle of the object file.

I was unable to proceed with further improvements to the `ObjectCompiler` and add a corresponding test due to a missing LLVM 18 dependency in the environment. The sandbox limitations prevented me from installing or building LLVM from source. This blocked any work that required compiling the `inkwell` crate.