### PR TITLE
Refactor parser expressions

### DIFF
--- a/genpay-codegen/src/lib.rs
+++ b/genpay-codegen/src/lib.rs
@@ -6,15 +6,18 @@ use crate::{
     structure::{Field, Structure},
     variable::Variable,
 };
-use genpay_parser::{expressions::Expressions, statements::Statements, types::Type, value::Value};
+use genpay_parser::{
+    expressions::Expressions, statements::Statements, token_type::TokenType, types::Type,
+    value::Value,
+};
 use inkwell::{
-    AddressSpace,
     basic_block::BasicBlock,
     builder::Builder,
     context::Context,
     module::{Linkage, Module},
     types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FunctionType},
     values::{BasicMetadataValueEnum, BasicValue, BasicValueEnum, FunctionValue, PointerValue},
+    AddressSpace,
 };
 
 use genpay_semantic::symtable::SymbolTable;
@@ -108,9 +111,21 @@ impl<'ctx> CodeGen<'ctx> {
             .for_each(|stmt| self.compile_statement(stmt, prefix));
 
         let module_content = {
-            let functions = self.scope.stricted_functions().map(|(k, v)| (*k, v.clone())).collect();
-            let structures = self.scope.stricted_structs().map(|(k, v)| (*k, v.clone())).collect();
-            let enumerations = self.scope.stricted_enums().map(|(k, v)| (*k, v.clone())).collect();
+            let functions = self
+                .scope
+                .stricted_functions()
+                .map(|(k, v)| (*k, v.clone()))
+                .collect();
+            let structures = self
+                .scope
+                .stricted_structs()
+                .map(|(k, v)| (*k, v.clone()))
+                .collect();
+            let enumerations = self
+                .scope
+                .stricted_enums()
+                .map(|(k, v)| (*k, v.clone()))
+                .collect();
 
             ModuleContent {
                 functions,
@@ -137,8 +152,8 @@ impl<'ctx> CodeGen<'ctx> {
 
                     self.builder.build_store(var.ptr, compiled_value.1).unwrap();
                 } else {
-                    let ptr = self
-                        .compile_expression(&object, Some(Type::Pointer(Box::new(Type::Undefined))));
+                    let ptr =
+                        self.compile_expression(&object, Some(Type::Pointer(Box::new(Type::Undefined))));
                     let value = self.compile_expression(&value, None);
 
                     let _ = self
@@ -605,12 +620,10 @@ impl<'ctx> CodeGen<'ctx> {
                 public: _,
                 span: _,
             } => {
-                let name = Box::leak(format!("{}{}", prefix.unwrap_or_default(), raw_name).into_boxed_str());
-                let llvm_name = format!(
-                    "{}.{}",
-                    self.module.get_name().to_string_lossy(),
-                    name
-                );
+                let name =
+                    Box::leak(format!("{}{}", prefix.unwrap_or_default(), raw_name).into_boxed_str());
+                let llvm_name =
+                    format!("{}.{}", self.module.get_name().to_string_lossy(), name);
 
                 let struct_type = self.context.opaque_struct_type(&llvm_name);
                 let mut compiled_fields = Vec::new();
@@ -652,7 +665,12 @@ impl<'ctx> CodeGen<'ctx> {
                         Some(Box::leak(format!("struct_{}__", name).into_boxed_str())),
                     );
 
-                    let (function_id, mut function_value) = self.scope.stricted_functions().last().map(|(id, f)| (*id, f.clone())).unwrap();
+                    let (function_id, mut function_value) = self
+                        .scope
+                        .stricted_functions()
+                        .last()
+                        .map(|(id, f)| (*id, f.clone()))
+                        .unwrap();
                     self.exit_scope_raw();
 
                     if let Some(Type::SelfRef) = function_value.arguments.first() {
@@ -663,7 +681,8 @@ impl<'ctx> CodeGen<'ctx> {
                         .set_function(function_id, function_value.clone());
 
                     let prefix_to_strip = format!("struct_{}__", name);
-                    let function_id_in_struct = function_id.strip_prefix(&prefix_to_strip).unwrap();
+                    let function_id_in_struct =
+                        function_id.strip_prefix(&prefix_to_strip).unwrap();
                     self.scope
                         .get_mut_struct(name)
                         .unwrap()
@@ -678,7 +697,8 @@ impl<'ctx> CodeGen<'ctx> {
                 public: _,
                 span: _,
             } => {
-                let name = Box::leak(format!("{}{}", prefix.unwrap_or_default(), name).into_boxed_str());
+                let name =
+                    Box::leak(format!("{}{}", prefix.unwrap_or_default(), name).into_boxed_str());
                 self.scope.set_enum(
                     name,
                     Enumeration {
@@ -701,7 +721,12 @@ impl<'ctx> CodeGen<'ctx> {
                         Some(Box::leak(format!("enum_{name}__").into_boxed_str())),
                     );
 
-                    let (function_id, function_value) = self.scope.stricted_functions().last().map(|(id, f)| (*id, f.clone())).unwrap();
+                    let (function_id, function_value) = self
+                        .scope
+                        .stricted_functions()
+                        .last()
+                        .map(|(id, f)| (*id, f.clone()))
+                        .unwrap();
                     self.exit_scope_raw();
 
                     let prefix_to_strip = format!("enum_{}__", name);
@@ -729,9 +754,9 @@ impl<'ctx> CodeGen<'ctx> {
             } => {
                 let condition = self.compile_expression(&condition, None);
 
-                let then_basic_block = self
-                    .context
-                    .append_basic_block(self.function.unwrap(), "__if_then");
+                let then_basic_block =
+                    self.context
+                        .append_basic_block(self.function.unwrap(), "__if_then");
                 let else_basic_block = if else_block.is_some() {
                     Some(
                         self.context
@@ -740,9 +765,9 @@ impl<'ctx> CodeGen<'ctx> {
                 } else {
                     None
                 };
-                let after_basic_block = self
-                    .context
-                    .append_basic_block(self.function.unwrap(), "__if_after");
+                let after_basic_block =
+                    self.context
+                        .append_basic_block(self.function.unwrap(), "__if_after");
 
                 self.builder
                     .build_conditional_branch(
@@ -785,12 +810,12 @@ impl<'ctx> CodeGen<'ctx> {
                 let condition_block = self
                     .context
                     .append_basic_block(self.function.unwrap(), "__while_condition");
-                let statements_block = self
-                    .context
-                    .append_basic_block(self.function.unwrap(), "__while_block");
-                let after_block = self
-                    .context
-                    .append_basic_block(self.function.unwrap(), "__while_after");
+                let statements_block =
+                    self.context
+                        .append_basic_block(self.function.unwrap(), "__while_block");
+                let after_block =
+                    self.context
+                        .append_basic_block(self.function.unwrap(), "__while_after");
 
                 let _ = self
                     .builder
@@ -830,20 +855,20 @@ impl<'ctx> CodeGen<'ctx> {
                 span,
             } => {
                 // blocks definition
-                let iterator_block = self
-                    .context
-                    .append_basic_block(self.function.unwrap(), "for_iterator");
-                let statements_block = self
-                    .context
-                    .append_basic_block(self.function.unwrap(), "for_block");
-                let after_block = self
-                    .context
-                    .append_basic_block(self.function.unwrap(), "for_after");
+                let iterator_block =
+                    self.context
+                        .append_basic_block(self.function.unwrap(), "for_iterator");
+                let statements_block =
+                    self.context
+                        .append_basic_block(self.function.unwrap(), "for_block");
+                let after_block =
+                    self.context
+                        .append_basic_block(self.function.unwrap(), "for_after");
 
                 // binding initialization
 
-                let mut compiled_iterator = self
-                    .compile_expression(&iterator, Some(Type::Pointer(Box::new(Type::Undefined))));
+                let mut compiled_iterator =
+                    self.compile_expression(&iterator, Some(Type::Pointer(Box::new(Type::Undefined))));
 
                 if let Type::Pointer(ptr_type) = compiled_iterator.0 {
                     compiled_iterator.0 = *ptr_type.clone();
@@ -918,9 +943,9 @@ impl<'ctx> CodeGen<'ctx> {
                             let err_block = self
                                 .context
                                 .insert_basic_block_after(checker_block, "int_integer_panic");
-                            let ok_block = self
-                                .context
-                                .insert_basic_block_after(err_block, "int_checker_ok");
+                            let ok_block =
+                                self.context
+                                    .insert_basic_block_after(err_block, "int_checker_ok");
 
                             self.builder
                                 .build_unconditional_branch(checker_block)
@@ -989,7 +1014,8 @@ impl<'ctx> CodeGen<'ctx> {
                     Type::Alias(alias) => {
                         // allocating iterator status
                         let status_varname = format!("@genpay_iterator_status_{}", &binding);
-                        let static_status_varname = Box::leak(status_varname.clone().into_boxed_str());
+                        let static_status_varname =
+                            Box::leak(status_varname.clone().into_boxed_str());
 
                         let iterator_fn = self
                             .scope
@@ -1094,7 +1120,8 @@ impl<'ctx> CodeGen<'ctx> {
                         // allocating iterator position
                         let iterator_position_varname =
                             format!("@genpay_iterator_position_{}", &binding);
-                        let static_iterator_position_varname = Box::leak(iterator_position_varname.clone().into_boxed_str());
+                        let static_iterator_position_varname =
+                            Box::leak(iterator_position_varname.clone().into_boxed_str());
                         let iterator_position_alloca = self
                             .builder
                             .build_alloca(self.context.i64_type(), &iterator_position_varname)
@@ -1263,11 +1290,8 @@ impl<'ctx> CodeGen<'ctx> {
                         // incrementing iterator position
                         let iterator_position_varname =
                             format!("@genpay_iterator_position_{}", &binding);
-                        let iterator_position_ptr = self
-                            .scope
-                            .get_variable(&iterator_position_varname)
-                            .unwrap()
-                            .ptr;
+                        let iterator_position_ptr =
+                            self.scope.get_variable(&iterator_position_varname).unwrap().ptr;
 
                         let value = self
                             .builder
@@ -1502,11 +1526,7 @@ impl<'ctx> CodeGen<'ctx> {
                     .iter()
                     .zip(function.arguments.clone())
                     .for_each(|(arg, fn_expected)| {
-                        args.push(
-                            self.compile_expression(arg, Some(fn_expected))
-                                .1
-                                .into(),
-                        )
+                        args.push(self.compile_expression(arg, Some(fn_expected)).1.into())
                     });
 
                 let mut return_type = function.datatype.clone();
@@ -1551,19 +1571,14 @@ impl<'ctx> CodeGen<'ctx> {
                     if let Value::Identifier(id) = val {
                         let var = self.scope.get_variable(id).unwrap();
 
-                        (
-                            Type::Pointer(Box::new(var.datatype.clone())),
-                            var.ptr.into(),
-                        )
+                        (Type::Pointer(Box::new(var.datatype.clone())), var.ptr.into())
                     } else {
                         unreachable!()
                     }
                 }
                 _ => {
-                    let value = self.compile_expression(
-                        object,
-                        Some(Type::Pointer(Box::new(Type::Undefined))),
-                    );
+                    let value =
+                        self.compile_expression(object, Some(Type::Pointer(Box::new(Type::Undefined))));
                     let alloca = self.builder.build_alloca(value.1.get_type(), "").unwrap();
                     let _ = self.builder.build_store(alloca, value.1);
 
@@ -1636,10 +1651,16 @@ impl<'ctx> CodeGen<'ctx> {
                         alloca
                     };
 
+                    let operand_as_string = match operand {
+                        TokenType::Minus => "-",
+                        TokenType::Not => "!",
+                        _ => unreachable!(),
+                    };
+
                     let object_ptr: BasicMetadataValueEnum = object_ptr.into();
                     let operand: BasicMetadataValueEnum = self
                         .builder
-                        .build_global_string_ptr(operand, "@genpay_operand")
+                        .build_global_string_ptr(operand_as_string, "@genpay_operand")
                         .unwrap()
                         .as_pointer_value()
                         .into();
@@ -1659,8 +1680,8 @@ impl<'ctx> CodeGen<'ctx> {
                     return (unary_function.datatype.clone(), function_output);
                 }
 
-                match *operand {
-                    "-" => match object_value.0 {
+                match operand {
+                    TokenType::Minus => match object_value.0 {
                         Type::I8
                         | Type::I16
                         | Type::I32
@@ -1670,7 +1691,8 @@ impl<'ctx> CodeGen<'ctx> {
                         | Type::U32
                         | Type::U64
                         | Type::USIZE => (
-                            genpay_semantic::Analyzer::unsigned_to_signed_integer(&object_value.0).unwrap(),
+                            genpay_semantic::Analyzer::unsigned_to_signed_integer(&object_value.0)
+                                .unwrap(),
                             self.builder
                                 .build_int_neg(object_value.1.into_int_value(), "")
                                 .unwrap()
@@ -1688,7 +1710,7 @@ impl<'ctx> CodeGen<'ctx> {
                         _ => unreachable!(),
                     },
 
-                    "!" => (
+                    TokenType::Not => (
                         object_value.0,
                         self.builder
                             .build_not(object_value.1.into_int_value(), "")
@@ -1747,8 +1769,8 @@ impl<'ctx> CodeGen<'ctx> {
                 };
 
                 let output = match senior_type.clone() {
-                    typ if genpay_semantic::Analyzer::is_integer(&typ) => match *operand {
-                        "+" => {
+                    typ if genpay_semantic::Analyzer::is_integer(&typ) => match operand {
+                        TokenType::Plus => {
                             if genpay_semantic::Analyzer::is_unsigned_integer(&typ) {
                                 self.builder
                                     .build_int_nsw_add(
@@ -1769,7 +1791,7 @@ impl<'ctx> CodeGen<'ctx> {
                                     .as_basic_value_enum()
                             }
                         }
-                        "-" => {
+                        TokenType::Minus => {
                             if genpay_semantic::Analyzer::is_unsigned_integer(&typ) {
                                 self.builder
                                     .build_int_nsw_sub(
@@ -1790,7 +1812,7 @@ impl<'ctx> CodeGen<'ctx> {
                                     .as_basic_value_enum()
                             }
                         }
-                        "*" => {
+                        TokenType::Multiply => {
                             if genpay_semantic::Analyzer::is_unsigned_integer(&typ) {
                                 self.builder
                                     .build_int_nsw_mul(
@@ -1811,7 +1833,7 @@ impl<'ctx> CodeGen<'ctx> {
                                     .as_basic_value_enum()
                             }
                         }
-                        "/" => {
+                        TokenType::Divide => {
                             if genpay_semantic::Analyzer::is_unsigned_integer(&typ) {
                                 self.builder
                                     .build_int_unsigned_div(
@@ -1832,7 +1854,7 @@ impl<'ctx> CodeGen<'ctx> {
                                     .as_basic_value_enum()
                             }
                         }
-                        "%" => {
+                        TokenType::Modulus => {
                             if genpay_semantic::Analyzer::is_unsigned_integer(&typ) {
                                 self.builder
                                     .build_int_unsigned_rem(
@@ -1858,8 +1880,8 @@ impl<'ctx> CodeGen<'ctx> {
                             "Unsupported for codegen operator found! Please open issue on Github!"
                         ),
                     },
-                    typ if genpay_semantic::Analyzer::is_float(&typ) => match *operand {
-                        "+" => self
+                    typ if genpay_semantic::Analyzer::is_float(&typ) => match operand {
+                        TokenType::Plus => self
                             .builder
                             .build_float_add(
                                 lhs_value.1.into_float_value(),
@@ -1868,7 +1890,7 @@ impl<'ctx> CodeGen<'ctx> {
                             )
                             .unwrap()
                             .as_basic_value_enum(),
-                        "-" => self
+                        TokenType::Minus => self
                             .builder
                             .build_float_sub(
                                 lhs_value.1.into_float_value(),
@@ -1877,7 +1899,7 @@ impl<'ctx> CodeGen<'ctx> {
                             )
                             .unwrap()
                             .as_basic_value_enum(),
-                        "*" => self
+                        TokenType::Multiply => self
                             .builder
                             .build_float_mul(
                                 lhs_value.1.into_float_value(),
@@ -1886,7 +1908,7 @@ impl<'ctx> CodeGen<'ctx> {
                             )
                             .unwrap()
                             .as_basic_value_enum(),
-                        "/" => self
+                        TokenType::Divide => self
                             .builder
                             .build_float_div(
                                 lhs_value.1.into_float_value(),
@@ -1918,9 +1940,13 @@ impl<'ctx> CodeGen<'ctx> {
                                 )
                                 .unwrap();
 
-                            let mut value = match *operand {
-                                "+" => self.builder.build_int_add(lhs_int, rhs_int, "").unwrap(),
-                                "-" => self.builder.build_int_sub(lhs_int, rhs_int, "").unwrap(),
+                            let mut value = match operand {
+                                TokenType::Plus => {
+                                    self.builder.build_int_add(lhs_int, rhs_int, "").unwrap()
+                                }
+                                TokenType::Minus => {
+                                    self.builder.build_int_sub(lhs_int, rhs_int, "").unwrap()
+                                }
                                 _ => unreachable!(),
                             }
                             .as_basic_value_enum();
@@ -1954,31 +1980,30 @@ impl<'ctx> CodeGen<'ctx> {
                     }
 
                     Type::Alias(alias) => {
-                        // let exp = Some(Type::Pointer(Box::new(Type::Undefined)));
-                        // let lhs_value = self.compile_expression(*lhs, exp.clone());
-                        // let rhs_value = self.compile_expression(*rhs, exp);
-
                         let structure = self.scope.get_struct(&alias).unwrap();
                         let binary_function = structure.functions.get("binary").unwrap();
 
                         let left_ptr = self
-                            .compile_expression(
-                                lhs,
-                                Some(Type::Pointer(Box::new(Type::Undefined))),
-                            )
+                            .compile_expression(lhs, Some(Type::Pointer(Box::new(Type::Undefined))))
                             .1;
                         let right_ptr = self
-                            .compile_expression(
-                                rhs,
-                                Some(Type::Pointer(Box::new(Type::Undefined))),
-                            )
+                            .compile_expression(rhs, Some(Type::Pointer(Box::new(Type::Undefined))))
                             .1;
+
+                        let operand_as_string = match operand {
+                            TokenType::Plus => "+",
+                            TokenType::Minus => "-",
+                            TokenType::Multiply => "*",
+                            TokenType::Divide => "/",
+                            TokenType::Modulus => "%",
+                            _ => unreachable!(),
+                        };
 
                         let left_ptr: BasicMetadataValueEnum = left_ptr.into();
                         let right_ptr: BasicMetadataValueEnum = right_ptr.into();
                         let operand: BasicMetadataValueEnum = self
                             .builder
-                            .build_global_string_ptr(operand, "@genpay_operand")
+                            .build_global_string_ptr(operand_as_string, "@genpay_operand")
                             .unwrap()
                             .as_pointer_value()
                             .into();
@@ -2007,8 +2032,7 @@ impl<'ctx> CodeGen<'ctx> {
                 ..
             } => {
                 let mut lhs_value = self.compile_expression(lhs, expected.clone());
-                let mut rhs_value =
-                    self.compile_expression(rhs, Some(lhs_value.0.clone()));
+                let mut rhs_value = self.compile_expression(rhs, Some(lhs_value.0.clone()));
 
                 if let Type::Alias(left) = &lhs_value.0
                     && let Type::Alias(right) = &rhs_value.0
@@ -2019,8 +2043,8 @@ impl<'ctx> CodeGen<'ctx> {
                     rhs_value.0 = Type::U8;
                 }
 
-                match *operand {
-                    "&&" => {
+                match operand {
+                    TokenType::And => {
                         return (
                             Type::Bool,
                             self.builder
@@ -2033,7 +2057,7 @@ impl<'ctx> CodeGen<'ctx> {
                                 .as_basic_value_enum(),
                         );
                     }
-                    "||" => {
+                    TokenType::Or => {
                         return (
                             Type::Bool,
                             self.builder
@@ -2056,7 +2080,7 @@ impl<'ctx> CodeGen<'ctx> {
                         } else {
                             lhs_value.1
                         };
-                        let result_value = if *operand == "==" {
+                        let result_value = if *operand == TokenType::Eq {
                             self.builder
                                 .build_is_null(leading_value.into_pointer_value(), "")
                                 .unwrap()
@@ -2073,12 +2097,12 @@ impl<'ctx> CodeGen<'ctx> {
 
                     typ if genpay_semantic::Analyzer::is_integer(&typ) || typ == Type::Char => {
                         let predicate = match *operand {
-                            ">" => inkwell::IntPredicate::SGT,
-                            "<" => inkwell::IntPredicate::SLT,
-                            "<=" | "=<" => inkwell::IntPredicate::SLE,
-                            ">=" | "=>" => inkwell::IntPredicate::SGE,
-                            "==" => inkwell::IntPredicate::EQ,
-                            "!=" => inkwell::IntPredicate::NE,
+                            TokenType::Bt => inkwell::IntPredicate::SGT,
+                            TokenType::Lt => inkwell::IntPredicate::SLT,
+                            TokenType::Leq => inkwell::IntPredicate::SLE,
+                            TokenType::Beq => inkwell::IntPredicate::SGE,
+                            TokenType::Eq => inkwell::IntPredicate::EQ,
+                            TokenType::Ne => inkwell::IntPredicate::NE,
                             _ => unreachable!(),
                         };
 
@@ -2098,12 +2122,12 @@ impl<'ctx> CodeGen<'ctx> {
 
                     typ if genpay_semantic::Analyzer::is_float(&typ) => {
                         let predicate = match *operand {
-                            ">" => inkwell::FloatPredicate::OGT,
-                            "<" => inkwell::FloatPredicate::OLT,
-                            "<=" | "=<" => inkwell::FloatPredicate::OLE,
-                            ">=" | "=>" => inkwell::FloatPredicate::OGE,
-                            "==" => inkwell::FloatPredicate::OEQ,
-                            "!=" => inkwell::FloatPredicate::ONE,
+                            TokenType::Bt => inkwell::FloatPredicate::OGT,
+                            TokenType::Lt => inkwell::FloatPredicate::OLT,
+                            TokenType::Leq => inkwell::FloatPredicate::OLE,
+                            TokenType::Beq => inkwell::FloatPredicate::OGE,
+                            TokenType::Eq => inkwell::FloatPredicate::OEQ,
+                            TokenType::Ne => inkwell::FloatPredicate::ONE,
                             _ => unreachable!(),
                         };
 
@@ -2142,12 +2166,12 @@ impl<'ctx> CodeGen<'ctx> {
                             .unwrap();
 
                         let int_predicate = match *operand {
-                            ">" => inkwell::IntPredicate::SGT,
-                            "<" => inkwell::IntPredicate::SLT,
-                            "<=" | "=<" => inkwell::IntPredicate::SLE,
-                            ">=" | "=>" => inkwell::IntPredicate::SGE,
-                            "==" => inkwell::IntPredicate::EQ,
-                            "!=" => inkwell::IntPredicate::NE,
+                            TokenType::Bt => inkwell::IntPredicate::SGT,
+                            TokenType::Lt => inkwell::IntPredicate::SLT,
+                            TokenType::Leq => inkwell::IntPredicate::SLE,
+                            TokenType::Beq => inkwell::IntPredicate::SGE,
+                            TokenType::Eq => inkwell::IntPredicate::EQ,
+                            TokenType::Ne => inkwell::IntPredicate::NE,
                             _ => unreachable!(),
                         };
 
@@ -2171,16 +2195,10 @@ impl<'ctx> CodeGen<'ctx> {
                         let compare_function = structure.functions.get("compare").unwrap();
 
                         let left_ptr = self
-                            .compile_expression(
-                                lhs,
-                                Some(Type::Pointer(Box::new(Type::Undefined))),
-                            )
+                            .compile_expression(lhs, Some(Type::Pointer(Box::new(Type::Undefined))))
                             .1;
                         let right_ptr = self
-                            .compile_expression(
-                                rhs,
-                                Some(Type::Pointer(Box::new(Type::Undefined))),
-                            )
+                            .compile_expression(rhs, Some(Type::Pointer(Box::new(Type::Undefined))))
                             .1;
 
                         let left_ptr: BasicMetadataValueEnum = left_ptr.into();
@@ -2201,12 +2219,12 @@ impl<'ctx> CodeGen<'ctx> {
                         // comparing
 
                         let int_predicate = match *operand {
-                            ">" => inkwell::IntPredicate::SGT,
-                            "<" => inkwell::IntPredicate::SLT,
-                            "<=" | "=<" => inkwell::IntPredicate::SLE,
-                            ">=" | "=>" => inkwell::IntPredicate::SGE,
-                            "==" => inkwell::IntPredicate::EQ,
-                            "!=" => inkwell::IntPredicate::NE,
+                            TokenType::Bt => inkwell::IntPredicate::SGT,
+                            TokenType::Lt => inkwell::IntPredicate::SLT,
+                            TokenType::Leq => inkwell::IntPredicate::SLE,
+                            TokenType::Beq => inkwell::IntPredicate::SGE,
+                            TokenType::Eq => inkwell::IntPredicate::EQ,
+                            TokenType::Ne => inkwell::IntPredicate::NE,
                             _ => unreachable!(),
                         };
 
@@ -2250,12 +2268,12 @@ impl<'ctx> CodeGen<'ctx> {
 
                 let sign_extend = genpay_semantic::Analyzer::is_unsigned_integer(&left.0);
                 let basic_value = match *operand {
-                    "<<" => self
+                    TokenType::LShift => self
                         .builder
                         .build_left_shift(left.1.into_int_value(), right.1.into_int_value(), "")
                         .unwrap()
                         .as_basic_value_enum(),
-                    ">>" => self
+                    TokenType::RShift => self
                         .builder
                         .build_right_shift(
                             left.1.into_int_value(),
@@ -2265,17 +2283,17 @@ impl<'ctx> CodeGen<'ctx> {
                         )
                         .unwrap()
                         .as_basic_value_enum(),
-                    "&" => self
+                    TokenType::Ampersand => self
                         .builder
                         .build_and(left.1.into_int_value(), right.1.into_int_value(), "")
                         .unwrap()
                         .as_basic_value_enum(),
-                    "|" => self
+                    TokenType::Verbar => self
                         .builder
                         .build_or(left.1.into_int_value(), right.1.into_int_value(), "")
                         .unwrap()
                         .as_basic_value_enum(),
-                    "^" => self
+                    TokenType::Xor => self
                         .builder
                         .build_xor(left.1.into_int_value(), right.1.into_int_value(), "")
                         .unwrap()
@@ -2339,19 +2357,18 @@ impl<'ctx> CodeGen<'ctx> {
                                         )
                                         .unwrap();
 
-                                    let value = if let Some(Type::Pointer(ptr_type)) =
-                                        expected.clone()
-                                    {
-                                        if *ptr_type == Type::Undefined {
-                                            ptr.as_basic_value_enum()
+                                    let value =
+                                        if let Some(Type::Pointer(ptr_type)) = expected.clone() {
+                                            if *ptr_type == Type::Undefined {
+                                                ptr.as_basic_value_enum()
+                                            } else {
+                                                self.builder
+                                                    .build_load(field.llvm_type, ptr, "")
+                                                    .unwrap()
+                                            }
                                         } else {
-                                            self.builder
-                                                .build_load(field.llvm_type, ptr, "")
-                                                .unwrap()
-                                        }
-                                    } else {
-                                        self.builder.build_load(field.llvm_type, ptr, "").unwrap()
-                                    };
+                                            self.builder.build_load(field.llvm_type, ptr, "").unwrap()
+                                        };
 
                                     prev_type = field.datatype.clone();
                                     prev_val = value;
@@ -2378,7 +2395,8 @@ impl<'ctx> CodeGen<'ctx> {
 
                             let tuple_type = self.context.struct_type(
                                 &types
-                                    .iter().map(|t| t.clone())
+                                    .iter()
+                                    .map(|t| t.clone())
                                     .map(|typ| self.get_basic_type(typ))
                                     .collect::<Vec<BasicTypeEnum>>(),
                                 false,
@@ -2445,9 +2463,7 @@ impl<'ctx> CodeGen<'ctx> {
                                             .iter()
                                             .zip(function.arguments.clone())
                                             .map(|(arg, exp)| {
-                                                self.compile_expression(arg, Some(exp))
-                                                    .1
-                                                    .into()
+                                                self.compile_expression(arg, Some(exp)).1.into()
                                             })
                                             .collect::<Vec<BasicMetadataValueEnum>>();
 
@@ -2476,8 +2492,7 @@ impl<'ctx> CodeGen<'ctx> {
                                 }
                             }
                             Type::ImportObject(import_name) => {
-                                let module_content =
-                                    self.imports.get(import_name).unwrap().clone();
+                                let module_content = self.imports.get(import_name).unwrap().clone();
                                 let function = module_content.functions.get(*name).unwrap();
 
                                 let arguments = arguments
@@ -2841,11 +2856,6 @@ impl<'ctx> CodeGen<'ctx> {
                     let field_value =
                         self.compile_expression(&field_expr, Some(struct_field.datatype.clone()));
 
-                    // let ordered_index = self
-                    //     .context
-                    //     .i64_type()
-                    //     .const_int(struct_field.nth as u64, false);
-
                     let field_ptr = self
                         .builder
                         .build_struct_gep(structure.llvm_type, struct_alloca, struct_field.nth, "")
@@ -2934,6 +2944,7 @@ impl<'ctx> CodeGen<'ctx> {
                         Type::F32 => (Type::F32, self.context.f32_type().const_float(float).into()),
                         Type::F64 => (Type::F64, self.context.f64_type().const_float(float).into()),
                         _ => (Type::F64, self.context.f64_type().const_float(float).into()),
+.
                     };
                 }
 
@@ -3157,9 +3168,7 @@ impl<'ctx> CodeGen<'ctx> {
             Type::Bool => self.context.bool_type().into(),
 
             Type::Pointer(_) => self.context.ptr_type(AddressSpace::default()).into(),
-            Type::Array(datatype, len) => {
-                self.get_basic_type(*datatype).array_type(len as u32).into()
-            }
+            Type::Array(datatype, len) => self.get_basic_type(*datatype).array_type(len as u32).into(),
             Type::DynamicArray(_) => todo!(),
 
             Type::Tuple(types) => {

--- a/genpay-codegen/src/lib.rs
+++ b/genpay-codegen/src/lib.rs
@@ -2944,7 +2944,6 @@ impl<'ctx> CodeGen<'ctx> {
                         Type::F32 => (Type::F32, self.context.f32_type().const_float(float).into()),
                         Type::F64 => (Type::F64, self.context.f64_type().const_float(float).into()),
                         _ => (Type::F64, self.context.f64_type().const_float(float).into()),
-.
                     };
                 }
 

--- a/genpay-lexer/src/token_type.rs
+++ b/genpay-lexer/src/token_type.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TokenType {
     Identifier, // abc
     Keyword,    // let

--- a/genpay-parser/src/expressions.rs
+++ b/genpay-parser/src/expressions.rs
@@ -9,32 +9,36 @@ use crate::{
 use genpay_lexer::token_type::TokenType;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+pub trait Spannable {
+    fn span(&self) -> (usize, usize);
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Expressions<'a> {
     /// `OBJECT BINOP EXPRESSION`
     Binary {
-        operand: &'a str,
+        operand: TokenType,
         lhs: &'a Expressions<'a>,
         rhs: &'a Expressions<'a>,
         span: (usize, usize),
     },
     /// `UNOP OBJECT`
     Unary {
-        operand: &'a str,
+        operand: TokenType,
         object: &'a Expressions<'a>,
         span: (usize, usize),
     },
 
     /// `OBJECT BOOLOP EXPRESSION`
     Boolean {
-        operand: &'a str,
+        operand: TokenType,
         lhs: &'a Expressions<'a>,
         rhs: &'a Expressions<'a>,
         span: (usize, usize),
     },
     /// `OBJECT BITOP EXPRESSION`
     Bitwise {
-        operand: &'a str,
+        operand: TokenType,
         lhs: &'a Expressions<'a>,
         rhs: &'a Expressions<'a>,
         span: (usize, usize),
@@ -111,167 +115,9 @@ pub enum Expressions<'a> {
     None,
 }
 
-impl<'a> PartialEq for Expressions<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                Expressions::Binary {
-                    operand: o1,
-                    lhs: lhs1,
-                    rhs: rhs1,
-                    ..
-                },
-                Expressions::Binary {
-                    operand: o2,
-                    lhs: lhs2,
-                    rhs: rhs2,
-                    ..
-                },
-            ) => o1 == o2 && lhs1 == lhs2 && rhs1 == rhs2,
-            (
-                Expressions::Unary {
-                    operand: o1,
-                    object: obj1,
-                    ..
-                },
-                Expressions::Unary {
-                    operand: o2,
-                    object: obj2,
-                    ..
-                },
-            ) => o1 == o2 && obj1 == obj2,
-            (
-                Expressions::Boolean {
-                    operand: o1,
-                    lhs: lhs1,
-                    rhs: rhs1,
-                    ..
-                },
-                Expressions::Boolean {
-                    operand: o2,
-                    lhs: lhs2,
-                    rhs: rhs2,
-                    ..
-                },
-            ) => o1 == o2 && lhs1 == lhs2 && rhs1 == rhs2,
-            (
-                Expressions::Bitwise {
-                    operand: o1,
-                    lhs: lhs1,
-                    rhs: rhs1,
-                    ..
-                },
-                Expressions::Bitwise {
-                    operand: o2,
-                    lhs: lhs2,
-                    rhs: rhs2,
-                    ..
-                },
-            ) => o1 == o2 && lhs1 == lhs2 && rhs1 == rhs2,
-            (
-                Expressions::Argument {
-                    name: n1,
-                    r#type: t1,
-                    ..
-                },
-                Expressions::Argument {
-                    name: n2,
-                    r#type: t2,
-                    ..
-                },
-            ) => n1 == n2 && t1 == t2,
-            (
-                Expressions::SubElement {
-                    head: h1,
-                    subelements: s1,
-                    ..
-                },
-                Expressions::SubElement {
-                    head: h2,
-                    subelements: s2,
-                    ..
-                },
-            ) => *h1 == *h2 && s1 == s2,
-            (
-                Expressions::FnCall {
-                    name: n1,
-                    arguments: a1,
-                    ..
-                },
-                Expressions::FnCall {
-                    name: n2,
-                    arguments: a2,
-                    ..
-                },
-            ) => n1 == n2 && a1 == a2,
-            (
-                Expressions::MacroCall {
-                    name: n1,
-                    arguments: a1,
-                    ..
-                },
-                Expressions::MacroCall {
-                    name: n2,
-                    arguments: a2,
-                    ..
-                },
-            ) => n1 == n2 && a1 == a2,
-            (Expressions::Reference { object: o1, .. }, Expressions::Reference { object: o2, .. }) => {
-                o1 == o2
-            }
-            (
-                Expressions::Dereference { object: o1, .. },
-                Expressions::Dereference { object: o2, .. },
-            ) => o1 == o2,
-            (
-                Expressions::Array {
-                    values: v1,
-                    len: l1,
-                    ..
-                },
-                Expressions::Array {
-                    values: v2,
-                    len: l2,
-                    ..
-                },
-            ) => l1 == l2 && v1 == v2,
-            (Expressions::Tuple { values: v1, .. }, Expressions::Tuple { values: v2, .. }) => v1 == v2,
-            (
-                Expressions::Slice {
-                    object: o1,
-                    index: i1,
-                    ..
-                },
-                Expressions::Slice {
-                    object: o2,
-                    index: i2,
-                    ..
-                },
-            ) => o1 == o2 && i1 == i2,
-            (
-                Expressions::Struct {
-                    name: n1,
-                    fields: f1,
-                    ..
-                },
-                Expressions::Struct {
-                    name: n2,
-                    fields: f2,
-                    ..
-                },
-            ) => n1 == n2 && f1 == f2,
-            (Expressions::Scope { block: b1, .. }, Expressions::Scope { block: b2, .. }) => b1 == b2,
-            (Expressions::Value(v1, _), Expressions::Value(v2, _)) => v1 == v2,
-            (Expressions::None, Expressions::None) => true,
-            _ => false,
-        }
-    }
-}
-
-impl<'a> Parser<'a> {
-    #[inline]
-    pub fn get_span_expression(expr: &Expressions<'a>) -> (usize, usize) {
-        match expr {
+impl<'a> Spannable for Expressions<'a> {
+    fn span(&self) -> (usize, usize) {
+        match self {
             Expressions::Binary { span, .. } => *span,
             Expressions::Boolean { span, .. } => *span,
             Expressions::Bitwise { span, .. } => *span,
@@ -291,12 +137,8 @@ impl<'a> Parser<'a> {
             Expressions::None => (0, 0),
         }
     }
-
-    #[inline]
-    pub fn span_expression(&self, expr: &Expressions<'a>) -> (usize, usize) {
-        Self::get_span_expression(expr)
-    }
 }
+
 
 use bumpalo::Bump;
 
@@ -308,7 +150,7 @@ impl<'a> Parser<'a> {
         expr_arena: &'a Bump,
         stmt_arena: &'a Bump,
     ) -> Expressions<'a> {
-        let head_span = Self::get_span_expression(&head);
+        let head_span = head.span();
         let head = expr_arena.alloc(head);
         let mut subelements = Vec::new();
         let mut end_span = head_span.1;
@@ -320,7 +162,7 @@ impl<'a> Parser<'a> {
             let _ = self.next();
 
             let term = self.term(expr_arena, stmt_arena);
-            end_span = Self::get_span_expression(&term).1;
+            end_span = term.span().1;
             subelements.push(term);
         }
 
@@ -332,16 +174,16 @@ impl<'a> Parser<'a> {
     }
 
     pub fn binary_expression(&mut self, node: Expressions<'a>, expr_arena: &'a Bump, stmt_arena: &'a Bump) -> Expressions<'a> {
-        let node_span = Self::get_span_expression(&node);
+        let node_span = node.span();
         let current = self.current();
 
         match current.token_type {
-            tty if BINARY_OPERATORS.contains(&tty) => {
+            ref tty if BINARY_OPERATORS.contains(&tty) => {
                 let _ = self.next();
 
                 let lhs = node;
                 let rhs = self.expression(expr_arena, stmt_arena);
-                let span_end = Self::get_span_expression(&rhs).1;
+                let span_end = rhs.span().1;
 
                 if PRIORITY_BINARY_OPERATORS.contains(&tty) {
                     let new_node = rhs.clone();
@@ -358,7 +200,7 @@ impl<'a> Parser<'a> {
                         let rhs_new = lhs;
 
                         let priority_node = Expressions::Binary {
-                            operand: current.value,
+                            operand: current.token_type.clone(),
                             lhs: lhs_new,
                             rhs: rhs_new,
                             span,
@@ -374,7 +216,7 @@ impl<'a> Parser<'a> {
                 }
 
                 Expressions::Binary {
-                    operand: current.value,
+                    operand: current.token_type,
                     lhs: expr_arena.alloc(lhs),
                     rhs: expr_arena.alloc(rhs),
                     span: (node_span.0, span_end),
@@ -387,22 +229,22 @@ impl<'a> Parser<'a> {
     pub fn boolean_expression(&mut self, node: Expressions<'a>, expr_arena: &'a Bump, stmt_arena: &'a Bump) -> Expressions<'a> {
         // FIXME: Expressions like `true || false` returns error "Undefined term found"
 
-        let node_span = Self::get_span_expression(&node);
+        let node_span = node.span();
         let current = self.current();
 
         match current.token_type {
-            op if PRIORITY_BOOLEAN_OPERATORS.contains(&op) => node,
-            op if BOOLEAN_OPERATORS.contains(&op) => {
+            ref op if PRIORITY_BOOLEAN_OPERATORS.contains(&op) => node,
+            ref op if BOOLEAN_OPERATORS.contains(&op) => {
                 let _ = self.next();
 
                 let lhs = node.clone();
                 let rhs = self.expression(expr_arena, stmt_arena);
-                let span_end = Self::get_span_expression(&rhs).1;
+                let span_end = rhs.span().1;
 
                 if PRIORITY_BOOLEAN_OPERATORS.contains(&self.current().token_type) {
-                    let operand = self.current().value;
+                    let operand = self.current().token_type.clone();
                     let lhs_node = Expressions::Boolean {
-                        operand: current.value,
+                        operand: current.token_type.clone(),
                         lhs: expr_arena.alloc(lhs),
                         rhs: expr_arena.alloc(rhs),
                         span: (current.span.0, self.current().span.1),
@@ -420,7 +262,7 @@ impl<'a> Parser<'a> {
                 }
 
                 Expressions::Boolean {
-                    operand: current.value,
+                    operand: current.token_type,
                     lhs: expr_arena.alloc(lhs),
                     rhs: expr_arena.alloc(rhs),
                     span: (node_span.0, span_end),
@@ -431,19 +273,19 @@ impl<'a> Parser<'a> {
     }
 
     pub fn bitwise_expression(&mut self, node: Expressions<'a>, expr_arena: &'a Bump, stmt_arena: &'a Bump) -> Expressions<'a> {
-        let node_span = Self::get_span_expression(&node);
+        let node_span = node.span();
         let current = self.current();
 
         match current.token_type {
-            tty if BITWISE_OPERATORS.contains(&tty) => {
+            ref tty if BITWISE_OPERATORS.contains(&tty) => {
                 let _ = self.next();
 
                 let lhs = expr_arena.alloc(node);
                 let rhs = expr_arena.alloc(self.expression(expr_arena, stmt_arena));
-                let span_end = Self::get_span_expression(&rhs).1;
+                let span_end = rhs.span().1;
 
                 Expressions::Bitwise {
-                    operand: current.value,
+                    operand: current.token_type,
                     lhs,
                     rhs,
                     span: (node_span.0, span_end),
@@ -475,7 +317,7 @@ impl<'a> Parser<'a> {
             self.expressions_enum(TokenType::LParen, TokenType::RParen, TokenType::Comma, expr_arena, stmt_arena);
 
         let span_end = if let Some(last_arg) = arguments.last() {
-            Self::get_span_expression(last_arg).1
+            last_arg.span().1
         } else {
             self.current().span.0
         };
@@ -496,7 +338,7 @@ impl<'a> Parser<'a> {
             self.expressions_enum(TokenType::LParen, TokenType::RParen, TokenType::Comma, expr_arena, stmt_arena);
 
         let span_end = if let Some(last_arg) = arguments.last() {
-            Self::get_span_expression(last_arg).1
+            last_arg.span().1
         } else {
             self.current().span.0
         };
@@ -522,7 +364,7 @@ impl<'a> Parser<'a> {
                 help: "Close slice index with brackets".to_string(),
                 src: self.source.clone(),
                 span: error::position_to_span((
-                    self.span_expression(&expr).0,
+                    expr.span().0,
                     self.current().span.1,
                 )),
             });
@@ -535,7 +377,7 @@ impl<'a> Parser<'a> {
         Expressions::Slice {
             object,
             index,
-            span: (self.span_expression(&expr).0, span_end),
+            span: (expr.span().0, span_end),
         }
     }
 

--- a/genpay-parser/src/lib.rs
+++ b/genpay-parser/src/lib.rs
@@ -1,7 +1,7 @@
 
 use crate::{
     error::{ParserError, ParserWarning},
-    expressions::{Expressions, Spannable},
+    expressions::Expressions,
     statements::Statements,
     types::Type,
     value::Value,
@@ -9,6 +9,9 @@ use crate::{
 use bumpalo::Bump;
 use genpay_lexer::{token::Token, token_type::TokenType, Lexer};
 use miette::NamedSource;
+
+pub use crate::expressions::Spannable;
+pub use genpay_lexer::token_type;
 
 /// Custom Defined Error Types
 pub mod error;
@@ -1002,7 +1005,6 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expressions::Spannable;
 
     #[test]
     fn get_basic_type_test() {

--- a/genpay-parser/src/lib.rs
+++ b/genpay-parser/src/lib.rs
@@ -1,7 +1,7 @@
 
 use crate::{
     error::{ParserError, ParserWarning},
-    expressions::Expressions,
+    expressions::{Expressions, Spannable},
     statements::Statements,
     types::Type,
     value::Value,
@@ -364,10 +364,10 @@ impl<'a> Parser<'a> {
 
             TokenType::Minus | TokenType::Not => {
                 let object = self.term(expr_arena, stmt_arena);
-                let span = (current.span.0, self.span_expression(&object).1);
+                let span = (current.span.0, object.span().1);
 
                 Expressions::Unary {
-                    operand: current.value,
+                    operand: current.token_type,
                     object: expr_arena.alloc(object),
                     span,
                 }
@@ -857,7 +857,7 @@ impl<'a> Parser<'a> {
                             | TokenType::Minus
                             | TokenType::Multiply
                             | TokenType::Divide => {
-                                let operand = self.current().value;
+                                let operand = self.current().token_type;
                                 let _ = self.next();
 
                                 if !self.expect(TokenType::Equal) {
@@ -916,10 +916,10 @@ impl<'a> Parser<'a> {
                         stmt_arena,
                     ),
 
-                    tty if BINARY_OPERATORS.contains(&tty) => match self.next().token_type {
+                    ref tty if BINARY_OPERATORS.contains(&tty) => match self.next().token_type {
                         TokenType::Equal => self.binary_assign_statement(
                             Expressions::Value(Value::Identifier(current.value), current.span),
-                            next.value,
+                            next.token_type,
                             current.span,
                             expr_arena,
                             stmt_arena,
@@ -927,7 +927,7 @@ impl<'a> Parser<'a> {
                         TokenType::Plus | TokenType::Minus => {
                             let span_start = next.span.0;
                             let span_end = self.current().span.1;
-                            let (op1, op2) = (next.value, self.current().value);
+                            let (op1, op2) = (next.token_type, self.current().token_type);
 
                             if op1 != op2 {
                                 self.error(ParserError::UnknownExpression {
@@ -1002,6 +1002,7 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::expressions::Spannable;
 
     #[test]
     fn get_basic_type_test() {
@@ -1056,7 +1057,7 @@ fn binary_expression() {
                 rhs,
                 span: _,
             } => {
-                assert_eq!(operand, "+");
+                assert_eq!(operand, TokenType::Plus);
 
                 if let Expressions::Value(Value::Integer(5), _) = *lhs {
                 } else {
@@ -1098,7 +1099,7 @@ fn binary_advanced_expression() {
                 rhs,
                 span: _,
             } => {
-                assert_eq!(operand, "+");
+                assert_eq!(operand, TokenType::Plus);
 
                 if let Expressions::Value(Value::Integer(2), _) = *lhs {
                 } else {
@@ -1111,7 +1112,7 @@ fn binary_advanced_expression() {
                     span: _,
                 } = *rhs
                 {
-                    assert_eq!(operand, "*");
+                    assert_eq!(operand, TokenType::Multiply);
 
                     if let Expressions::Value(Value::Integer(2), _) = *lhs {
                     } else {
@@ -1155,7 +1156,7 @@ fn unary_negative_expression() {
                 object,
                 span: _,
             } => {
-                assert_eq!(operand, "-");
+                assert_eq!(operand, TokenType::Minus);
 
                 if let Expressions::Value(Value::Integer(2), _) = *object {
                 } else {
@@ -1192,7 +1193,7 @@ fn unary_not_expression() {
                 object,
                 span: _,
             } => {
-                assert_eq!(operand, "!");
+                assert_eq!(operand, TokenType::Not);
 
                 if let Expressions::Value(Value::Integer(2), _) = *object {
                 } else {
@@ -1230,7 +1231,7 @@ fn boolean_eq_expression() {
                 rhs,
                 span: _,
             } => {
-                assert_eq!(operand, "==");
+                assert_eq!(operand, TokenType::Eq);
 
                 if let Expressions::Value(Value::Integer(1), _) = *lhs {
                 } else {
@@ -1272,7 +1273,7 @@ fn boolean_ne_expression() {
                 rhs,
                 span: _,
             } => {
-                assert_eq!(operand, "!=");
+                assert_eq!(operand, TokenType::Ne);
 
                 if let Expressions::Value(Value::Integer(1), _) = *lhs {
                 } else {
@@ -1314,7 +1315,7 @@ fn boolean_bt_expression() {
                 rhs,
                 span: _,
             } => {
-                assert_eq!(operand, ">");
+                assert_eq!(operand, TokenType::Bt);
 
                 if let Expressions::Value(Value::Integer(1), _) = *lhs {
                 } else {
@@ -1356,7 +1357,7 @@ fn boolean_lt_expression() {
                 rhs,
                 span: _,
             } => {
-                assert_eq!(operand, "<");
+                assert_eq!(operand, TokenType::Lt);
 
                 if let Expressions::Value(Value::Integer(1), _) = *lhs {
                 } else {
@@ -1398,7 +1399,7 @@ fn boolean_advanced_expression() {
                 rhs,
                 span: _,
             } => {
-                assert_eq!(operand, "&&");
+                assert_eq!(operand, TokenType::And);
 
                 if let Expressions::Boolean {
                     operand,
@@ -1407,7 +1408,7 @@ fn boolean_advanced_expression() {
                     span: _,
                 } = *lhs
                 {
-                    assert_eq!(operand, "==");
+                    assert_eq!(operand, TokenType::Eq);
 
                     if let Expressions::Value(Value::Integer(1), _) = *lhs {
                     } else {
@@ -1428,7 +1429,7 @@ fn boolean_advanced_expression() {
                     span: _,
                 } = *rhs
                 {
-                    assert_eq!(operand, "!=");
+                    assert_eq!(operand, TokenType::Ne);
 
                     if let Expressions::Value(Value::Integer(0), _) = *lhs {
                     } else {
@@ -1473,7 +1474,7 @@ fn bitwise_expression() {
                 rhs,
                 span: _,
             } => {
-                assert_eq!(operand, "<<");
+                assert_eq!(operand, TokenType::LShift);
 
                 if let Expressions::Value(Value::Integer(5), _) = *lhs {
                 } else {
@@ -2134,7 +2135,7 @@ fn binary_assign_statement() {
                 assert_eq!(*identifier, "some_var");
             }
 
-            assert_eq!(*operand, "+");
+            assert_eq!(*operand, TokenType::Plus);
 
             if let Expressions::Value(Value::Integer(5), _) = value {
             } else {

--- a/genpay-parser/src/statements.rs
+++ b/genpay-parser/src/statements.rs
@@ -1,12 +1,44 @@
 use crate::{
     END_STATEMENT, Parser,
     error::{self, ParserError},
-    expressions::Expressions,
+    expressions::{Expressions, Spannable},
     types::Type,
     value::Value,
 };
 use genpay_lexer::token_type::TokenType;
 use std::collections::BTreeMap;
+
+impl<'a> Spannable for Statements<'a> {
+    fn span(&self) -> (usize, usize) {
+        match self {
+            Statements::AssignStatement { span, .. } => *span,
+            Statements::BinaryAssignStatement { span, .. } => *span,
+            Statements::DerefAssignStatement { span, .. } => *span,
+            Statements::SliceAssignStatement { span, .. } => *span,
+            Statements::FieldAssignStatement { span, .. } => *span,
+            Statements::AnnotationStatement { span, .. } => *span,
+            Statements::FunctionDefineStatement { span, .. } => *span,
+            Statements::FunctionCallStatement { span, .. } => *span,
+            Statements::MacroCallStatement { span, .. } => *span,
+            Statements::StructDefineStatement { span, .. } => *span,
+            Statements::EnumDefineStatement { span, .. } => *span,
+            Statements::TypedefStatement { span, .. } => *span,
+            Statements::IfStatement { span, .. } => *span,
+            Statements::WhileStatement { span, .. } => *span,
+            Statements::ForStatement { span, .. } => *span,
+            Statements::ImportStatement { span, .. } => *span,
+            Statements::IncludeStatement { span, .. } => *span,
+            Statements::ExternStatement { span, .. } => *span,
+            Statements::ExternDeclareStatement { span, .. } => *span,
+            Statements::LinkCStatement { span, .. } => *span,
+            Statements::BreakStatements { span } => *span,
+            Statements::ReturnStatement { span, .. } => *span,
+            Statements::ScopeStatement { span, .. } => *span,
+            Statements::Expression(expr) => expr.span(),
+            Statements::None => (0, 0),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum Statements<'a> {
@@ -20,7 +52,7 @@ pub enum Statements<'a> {
     /// `OBJECT BINOP= EXPRESSION`
     BinaryAssignStatement {
         object: Expressions<'a>,
-        operand: &'a str,
+        operand: TokenType,
         value: Expressions<'a>,
         span: (usize, usize),
     },
@@ -464,39 +496,6 @@ impl<'a> PartialEq for Statements<'a> {
     }
 }
 
-impl<'a> Parser<'a> {
-    #[inline]
-    pub fn get_span_statement(stmt: &Statements<'a>) -> (usize, usize) {
-        match stmt {
-            Statements::AssignStatement { span, .. } => *span,
-            Statements::BinaryAssignStatement { span, .. } => *span,
-            Statements::DerefAssignStatement { span, .. } => *span,
-            Statements::SliceAssignStatement { span, .. } => *span,
-            Statements::FieldAssignStatement { span, .. } => *span,
-            Statements::AnnotationStatement { span, .. } => *span,
-            Statements::FunctionDefineStatement { span, .. } => *span,
-            Statements::FunctionCallStatement { span, .. } => *span,
-            Statements::MacroCallStatement { span, .. } => *span,
-            Statements::StructDefineStatement { span, .. } => *span,
-            Statements::EnumDefineStatement { span, .. } => *span,
-            Statements::TypedefStatement { span, .. } => *span,
-            Statements::IfStatement { span, .. } => *span,
-            Statements::WhileStatement { span, .. } => *span,
-            Statements::ForStatement { span, .. } => *span,
-            Statements::ImportStatement { span, .. } => *span,
-            Statements::IncludeStatement { span, .. } => *span,
-            Statements::ExternStatement { span, .. } => *span,
-            Statements::ExternDeclareStatement { span, .. } => *span,
-            Statements::LinkCStatement { span, .. } => *span,
-            Statements::BreakStatements { span } => *span,
-            Statements::ReturnStatement { span, .. } => *span,
-            Statements::ScopeStatement { span, .. } => *span,
-            Statements::Expression(expr) => Self::get_span_expression(expr),
-            Statements::None => (0, 0), // или можно вернуть Option<(usize, usize)>
-        }
-    }
-}
-
 use bumpalo::Bump;
 
 impl<'a> Parser<'a> {
@@ -538,7 +537,7 @@ impl<'a> Parser<'a> {
                     identifier: id,
                     datatype,
                     value: Some(value.clone()),
-                    span: (span_start, self.span_expression(&value).1),
+                    span: (span_start, value.span().1),
                 }
             }
             END_STATEMENT => {
@@ -603,7 +602,7 @@ impl<'a> Parser<'a> {
         }
 
         let path = self.expression(expr_arena, stmt_arena);
-        let span_end = Self::get_span_expression(&path).1;
+        let span_end = path.span().1;
 
         self.skip_eos();
 
@@ -930,7 +929,7 @@ impl<'a> Parser<'a> {
                         exception: "unexpected argument declaration found".to_string(),
                         help: "Use right arguments syntax: `identifier: type`".to_string(),
                         src: self.source.clone(),
-                        span: error::position_to_span(self.span_expression(&arg.clone())),
+                        span: error::position_to_span(arg.span()),
                     });
 
                     ("", Type::Void)
@@ -1006,7 +1005,7 @@ impl<'a> Parser<'a> {
             self.expression(expr_arena, stmt_arena)
         };
 
-        let end_span = Self::get_span_expression(&return_expr).1;
+        let end_span = return_expr.span().1;
         Statements::ReturnStatement {
             value: return_expr,
             span: (span_start, end_span),
@@ -1030,7 +1029,7 @@ impl<'a> Parser<'a> {
         }
 
         let value = self.expression(expr_arena, stmt_arena);
-        let end_span = Self::get_span_expression(&value).1;
+        let end_span = value.span().1;
         self.skip_eos();
 
         Statements::AssignStatement {
@@ -1043,7 +1042,7 @@ impl<'a> Parser<'a> {
     pub fn binary_assign_statement(
         &mut self,
         object: Expressions<'a>,
-        op: &'a str,
+        op: TokenType,
         span: (usize, usize),
         expr_arena: &'a Bump,
         stmt_arena: &'a Bump,
@@ -1053,7 +1052,7 @@ impl<'a> Parser<'a> {
         }
 
         let value = self.expression(expr_arena, stmt_arena);
-        let end_span = Self::get_span_expression(&value).1;
+        let end_span = value.span().1;
         self.skip_eos();
 
         Statements::BinaryAssignStatement {
@@ -1102,7 +1101,7 @@ impl<'a> Parser<'a> {
         let _ = self.next(); // consume '='
 
         let value_expr = self.expression(expr_arena, stmt_arena);
-        let end_span = Self::get_span_expression(&value_expr).1;
+        let end_span = value_expr.span().1;
         self.skip_eos();
 
         Statements::SliceAssignStatement {
@@ -1135,7 +1134,7 @@ impl<'a> Parser<'a> {
             self.expressions_enum(TokenType::LParen, TokenType::RParen, TokenType::Comma, expr_arena, stmt_arena);
 
         let span_end = if let Some(last_arg) = arguments.last() {
-            Self::get_span_expression(last_arg).1
+            last_arg.span().1
         } else {
             self.current().span.0
         };
@@ -1158,7 +1157,7 @@ impl<'a> Parser<'a> {
             self.expressions_enum(TokenType::LParen, TokenType::RParen, TokenType::Comma, expr_arena, stmt_arena);
 
         let span_end = if let Some(last_arg) = arguments.last() {
-            Self::get_span_expression(last_arg).1
+            last_arg.span().1
         } else {
             self.current().span.0
         };
@@ -1529,7 +1528,7 @@ impl<'a> Parser<'a> {
         }
 
         let path = self.expression(expr_arena, stmt_arena);
-        let span_end = Self::get_span_expression(&path).1;
+        let span_end = path.span().1;
 
         if let Expressions::Value(Value::String(_), _) = path {
             Statements::LinkCStatement {

--- a/genpay-semantic/src/lib.rs
+++ b/genpay-semantic/src/lib.rs
@@ -7,7 +7,13 @@ use crate::{
 };
 use bumpalo::Bump;
 use genpay_parser::{
-    expressions::Expressions, statements::Statements, types::Type, value::Value, Parser,
+    expressions::Expressions,
+    statements::Statements,
+    token_type::TokenType,
+    types::Type,
+    value::Value,
+    Parser,
+    Spannable,
 };
 use miette::NamedSource;
 use std::{
@@ -87,51 +93,6 @@ impl<'s> Analyzer<'s> {
         expr_arena: &'s Bump,
         stmt_arena: &'s Bump,
     ) -> Result<SemanticOk<'s>, SemanticErr<'s>> {
-        // let pre_statements = ast
-        //     .iter()
-        //     .filter(|stmt| {
-        //         matches!(
-        //             stmt,
-        //             Statements::StructDefineStatement {
-        //                 name: _,
-        //                 fields: _,
-        //                 functions: _,
-        //                 public: _,
-        //                 span: _
-        //             } | Statements::EnumDefineStatement {
-        //                 name: _,
-        //                 fields: _,
-        //                 functions: _,
-        //                 public: _,
-        //                 span: _
-        //             } | Statements::TypedefStatement {
-        //                 alias: _,
-        //                 datatype: _,
-        //                 span: _
-        //             } | Statements::ImportStatement { path: _, span: _ }
-        //                 | Statements::ExternStatement {
-        //                     identifier: _,
-        //                     arguments: _,
-        //                     return_type: _,
-        //                     extern_type: _,
-        //                     is_var_args: _,
-        //                     public: _,
-        //                     span: _
-        //                 }
-        //         )
-        //     })
-        //     .collect::<Vec<&Statements>>();
-        //
-        // let after_statements = ast.iter().filter(|stmt| !pre_statements.contains(stmt));
-        //
-        // pre_statements
-        //     .clone()
-        //     .into_iter()
-        //     .for_each(|stmt| self.visit_statement(stmt, expr_arena, stmt_arena));
-        // after_statements
-        //     .into_iter()
-        //     .for_each(|stmt| self.visit_statement(stmt, expr_arena, stmt_arena));
-
         ast.iter()
             .for_each(|stmt| self.visit_statement(stmt, expr_arena, stmt_arena));
 
@@ -230,17 +191,11 @@ impl<'s> Analyzer<'s> {
                 } => {}
                 Statements::LinkCStatement { path: _, span: _ } => {}
                 _ => {
-                    // if let Some(err) = self.errors.last() {
-                    //     if err.span == (255, 0).into() {
-                    //         return;
-                    //     };
-                    // }
-
                     self.error(SemanticError::SemanticalError {
                         exception: "This item is not allowed in global scope".to_string(),
                         help: Some("Consider removing this item from global scope".to_string()),
                         src: self.source.clone(),
-                        span: error::position_to_span(Parser::get_span_statement(statement)),
+                        span: error::position_to_span(statement.span()),
                     });
 
                     return;
@@ -444,10 +399,6 @@ impl<'s> Analyzer<'s> {
                 let instance = self.visit_expression(object, None, expr_arena, stmt_arena);
                 match instance {
                     Type::Array(typ, _) => {
-                        // i could spent some time to implement evaluating expressions for
-                        // checking index out of bounds, but it will be like in Rust: panics at
-                        // the runtime
-
                         let index_type =
                             self.visit_expression(index, Some(Type::USIZE), expr_arena, stmt_arena);
 
@@ -480,29 +431,7 @@ impl<'s> Analyzer<'s> {
                         }
                     }
                     Type::DynamicArray(_) => {
-                        // TODO: Remove dynamic array type
-
                         unreachable!()
-
-                        // let index_type = self.visit_expression(index, Some(Type::USIZE));
-                        //
-                        // if index_type != Type::USIZE {
-                        //     self.error(
-                        //         format!(
-                        //             "Expected index with type `usize`, but found `{index_type}`"
-                        //         ),
-                        //         *span,
-                        //     );
-                        // }
-                        //
-                        // let value_type = self.visit_expression(value, Some(*typ.clone()));
-                        //
-                        // if value_type != *typ {
-                        //     self.error(
-                        //         format!("Array has type `{typ}`, but found `{value_type}`"),
-                        //         *span,
-                        //     );
-                        // }
                     }
                     Type::Pointer(ptr_type) => {
                         let value_type =
@@ -651,7 +580,7 @@ impl<'s> Analyzer<'s> {
 
                 match (datatype, value) {
                     (Some(datatype), Some(value)) => {
-                        let value_span = Parser::get_span_expression(value);
+                        let value_span = value.span();
                         let value_type =
                             self.visit_expression(value, Some(datatype.clone()), expr_arena, stmt_arena);
 
@@ -912,9 +841,7 @@ impl<'s> Analyzer<'s> {
                                     ),
                                     help: Some("Consider verifying provided argument".to_string()),
                                     src: self.source.clone(),
-                                    span: error::position_to_span(Parser::get_span_expression(
-                                        &arguments[ind],
-                                    )),
+                                    span: error::position_to_span(arguments[ind].span()),
                                 });
                             }
                         },
@@ -1032,31 +959,7 @@ impl<'s> Analyzer<'s> {
                     }
                 });
 
-                // let functions_signatures = self.scope.functions.clone();
                 self.scope = *self.scope.parent.clone().unwrap();
-
-                // let _ = self.scope.structures.remove(name);
-
-                // let struct_type = Type::Struct(
-                //     fields.clone(),
-                //     functions_signatures
-                //         .into_iter()
-                //         .map(|x| (
-                //             x.0.replace("@!", ""),
-                //             x.1.datatype
-                //         ))
-                //         .collect(),
-                // );
-                // self.scope
-                //     .add_struct(name.clone(), struct_type.clone(), *public)
-                //     .unwrap_or_else(|err| {
-                //         self.error(err, *span);
-                //     });
-                // self.scope
-                //     .add_typedef(name.clone(), struct_type)
-                //     .unwrap_or_else(|err| {
-                //         self.error(err, *span);
-                //     })
             }
             Statements::EnumDefineStatement {
                 name,
@@ -1077,7 +980,6 @@ impl<'s> Analyzer<'s> {
                 enum_scope.parent = Some(Box::new(self.scope.clone()));
                 self.scope = enum_scope;
 
-                // WARN: Methods in enums are currently disabled
                 if !functions.is_empty() {
                     self.error(SemanticError::DisabledFeature {
                         exception: "methods in enums are currently disabled".to_string(),
@@ -1087,10 +989,6 @@ impl<'s> Analyzer<'s> {
                     });
                 }
 
-                // functions.iter().for_each(|func| {
-                //     self.visit_statement(func.1);
-                // });
-                //
                 let functions_signatures = self.scope.functions.clone();
                 self.scope = *self.scope.parent.clone().unwrap();
 
@@ -1462,149 +1360,6 @@ impl<'s> Analyzer<'s> {
                     src: self.source.clone(),
                     span: error::position_to_span(*span),
                 });
-
-                // match path {
-                //     Expressions::Value(Value::String(path), _) => {
-                //         let fname = std::path::Path::new(path)
-                //             .file_name()
-                //             .map(|fname| fname.to_str().unwrap_or("$NONE"));
-                //
-                //         match fname {
-                //             Some(fname) => {
-                //                 if fname == "$NONE" {
-                //                     self.error(format!("Unable to get module name: `{}`", path), *span);
-                //                     return;
-                //                 }
-                //
-                //                 let src = std::fs::read_to_string(fname).unwrap_or_else(|err| {
-                //                     self.error(format!("Unable to read `{}`: {}", fname, err), *span);
-                //                     String::new()
-                //                 });
-                //
-                //                 if src.is_empty() {
-                //                     return;
-                //                 };
-                //
-                //                 let mut lexer = genpay_lexer::Lexer::new(&src, fname);
-                //                 let (tokens, warns) = match lexer.tokenize() {
-                //                     Ok(res) => res,
-                //                     Err((errors, warns)) => {
-                //                         errors
-                //                             .iter()
-                //                             .for_each(|err| self.errors.push(err.clone().into()));
-                //                         warns
-                //                             .iter()
-                //                             .for_each(|warn| self.warnings.push(warn.clone().into()));
-                //                         return;
-                //                     }
-                //                 };
-                //                 warns
-                //                     .iter()
-                //                     .for_each(|warn| self.warnings.push(warn.clone().into()));
-                //
-                //                 let mut parser = genpay_parser::Parser::new(tokens, &src, fname);
-                //                 let (ast, warns) = match parser.parse() {
-                //                     Ok(res) => res,
-                //                     Err((errors, warns)) => {
-                //                         errors
-                //                             .iter()
-                //                             .for_each(|err| self.errors.push(err.clone().into()));
-                //                         warns
-                //                             .iter()
-                //                             .for_each(|warn| self.warnings.push(warn.clone().into()));
-                //                         return;
-                //                     }
-                //                 };
-                //                 warns
-                //                     .iter()
-                //                     .for_each(|warn| self.warnings.push(warn.clone().into()));
-                //
-                //                 let mut mutual_import = false;
-                //                 ast.iter().for_each(|stmt| {
-                //                     if let Statements::ImportStatement {
-                //                         path: Expressions::Value(Value::String(path), _),
-                //                         span,
-                //                     } = stmt
-                //                     {
-                //                         let imp_name = std::path::Path::new(path)
-                //                             .file_name()
-                //                             .map(|fname| fname.to_str().unwrap_or("$NONE"));
-                //
-                //                         if imp_name == Some(self.source.name()) {
-                //                             self.error(
-                //                                 format!(
-                //                                     "Mutual import found: `{}` from `{}`",
-                //                                     imp_name.unwrap(),
-                //                                     fname
-                //                                 ),
-                //                                 *span,
-                //                             );
-                //                             mutual_import = true;
-                //                         }
-                //                     }
-                //                 });
-                //
-                //                 if mutual_import {
-                //                     return;
-                //                 };
-                //
-                //                 let mut analyzer = Self::new(&src, fname, false);
-                //                 let (embedded_symtable, warns) = match analyzer.analyze(&ast) {
-                //                     Ok(warns) => warns,
-                //                     Err((errors, warns)) => {
-                //                         errors.iter().for_each(|err| self.errors.push(err.clone()));
-                //                         warns
-                //                             .iter()
-                //                             .for_each(|warn| self.warnings.push(warn.clone()));
-                //                         return;
-                //                     }
-                //                 };
-                //                 warns
-                //                     .iter()
-                //                     .for_each(|warn| self.warnings.push(warn.clone()));
-                //
-                //                 let module_name = fname
-                //                     .split(".")
-                //                     .nth(0)
-                //                     .map(|n| n.to_string())
-                //                     .unwrap_or(fname.replace(".dn", ""));
-                //
-                //                 let mut import = Import::new(ast, &src);
-                //
-                //                 analyzer.scope.functions.into_iter().for_each(|func| {
-                //                     if func.1.public {
-                //                         import.add_fn(func.0.to_string(), func.1.datatype);
-                //                     }
-                //                 });
-                //
-                //                 analyzer.scope.structures.into_iter().for_each(|structure| {
-                //                     if structure.1.public {
-                //                         import
-                //                             .add_struct(structure.0.to_string(), structure.1.datatype);
-                //                     }
-                //                 });
-                //
-                //                 analyzer.scope.enums.into_iter().for_each(|enumeration| {
-                //                     if enumeration.1.public {
-                //                         import.add_enum(
-                //                             enumeration.0.to_string(),
-                //                             enumeration.1.datatype,
-                //                         );
-                //                     }
-                //                 });
-                //
-                //                 import.embedded_symtable = embedded_symtable;
-                //                 self.symtable.imports.insert(module_name, import);
-                //             }
-                //             None => {
-                //                 self.error(format!("Unable to find: `{}`", path), *span);
-                //             }
-                //         }
-                //     }
-                //     _ => {
-                //         self.error(String::from("Import must be string constant"), *span);
-                //     }
-                // }
             }
 
             Statements::IncludeStatement { path, span: _ } => {
@@ -1697,8 +1452,6 @@ impl<'s> Analyzer<'s> {
 
                 self.scope
                     .add_var(identifier, datatype.clone(), true, (0, 0));
-
-                // making variable `used`
                 let _ = self.scope.get_var(identifier);
             }
 
@@ -1886,7 +1639,7 @@ impl<'s> Analyzer<'s> {
                     self.warning(SemanticWarning::UnusedResult {
                         message: format!("unused result with type `{expr_type}`"),
                         src: self.source.clone(),
-                        span: error::position_to_span(Parser::get_span_expression(expr)),
+                        span: error::position_to_span(expr.span()),
                     });
                 }
             }
@@ -1936,7 +1689,7 @@ impl<'s> Analyzer<'s> {
                     }
 
                     (Type::Pointer(_), r) if Self::is_integer(&r) => {
-                        if *operand != "+" && *operand != "-" {
+                        if *operand != TokenType::Plus && *operand != TokenType::Minus {
                             self.error(SemanticError::OperatorException {
                                 exception: "unsupported binary operator for pointer".to_string(),
                                 help: Some(
@@ -1951,7 +1704,7 @@ impl<'s> Analyzer<'s> {
                     }
 
                     (Type::Pointer(_), Type::Pointer(_)) => {
-                        if *operand != "+" && *operand != "-" {
+                        if *operand != TokenType::Plus && *operand != TokenType::Minus {
                             self.error(SemanticError::OperatorException {
                                 exception: "unsupported binary operator for pointer".to_string(),
                                 help: Some(
@@ -2057,15 +1810,15 @@ impl<'s> Analyzer<'s> {
                 let obj = self.visit_expression(object, expected.clone(), expr_arena, stmt_arena);
 
                 match (&obj, *operand) {
-                    (typ, "-") if Self::is_integer(typ) => {
+                    (typ, TokenType::Minus) if Self::is_integer(typ) => {
                         if Self::is_unsigned_integer(typ) {
                             return Self::unsigned_to_signed_integer(typ).unwrap();
                         }
                         obj
                     }
-                    (typ, "-") if Self::is_float(typ) => obj,
-                    (typ, "!") if Self::is_integer(typ) => obj,
-                    (Type::Bool, "!") => obj,
+                    (typ, TokenType::Minus) if Self::is_float(typ) => obj,
+                    (typ, TokenType::Not) if Self::is_integer(typ) => obj,
+                    (Type::Bool, TokenType::Not) => obj,
 
                     (Type::Alias(alias), _) => {
                         let implementation_format =
@@ -2148,7 +1901,7 @@ impl<'s> Analyzer<'s> {
                         if (matches!(l, Type::Pointer(_)) && r == Type::Null)
                             || (matches!(r, Type::Pointer(_)) && l == Type::Null) =>
                     {
-                        if !matches!(*operand, "==" | "!=") {
+                        if !matches!(*operand, TokenType::Eq | TokenType::Ne) {
                             self.error(SemanticError::OperatorException {
                                 exception: "null checker only supports: `==` / `!=`".to_string(),
                                 help: None,
@@ -2290,7 +2043,9 @@ impl<'s> Analyzer<'s> {
                     return expected.unwrap_or(left);
                 };
 
-                if [">>", "<<"].contains(operand) && !Self::is_unsigned_integer(&right) {
+                if [TokenType::RShift, TokenType::LShift].contains(operand)
+                    && !Self::is_unsigned_integer(&right)
+                {
                     self.error(SemanticError::TypesMismatch {
                         exception: "shift index must be unsigned integer".to_string(),
                         help: None,
@@ -2478,7 +2233,7 @@ impl<'s> Analyzer<'s> {
                                                 let self_arg = if is_pointed_struct {
                                                     prev_expr.clone()
                                                 } else {
-                                                    Expressions::Reference { object: expr_arena.alloc(prev_expr.clone()), span: (Parser::get_span_expression(&prev_expr)) }
+                                                    Expressions::Reference { object: expr_arena.alloc(prev_expr.clone()), span: (prev_expr.span()) }
                                                 };
 
                                                 arguments.push(self_arg);
@@ -2545,7 +2300,7 @@ impl<'s> Analyzer<'s> {
                                                     exception: format!("argument #{} has type `{}`, but found `{}`", index + 1, raw_expected, raw_expr_type),
                                                     help: None,
                                                     src: self.source.clone(),
-                                                    span: error::position_to_span(Parser::get_span_expression(expr))
+                                                    span: error::position_to_span(expr.span())
                                                 });
                                             }
                                         });
@@ -2614,19 +2369,14 @@ impl<'s> Analyzer<'s> {
                                                     exception: format!("argument #{} has type `{}`, but found `{}`", index + 1, expected, expr_type),
                                                     help: None,
                                                     src: self.source.clone(),
-                                                    span: error::position_to_span(Parser::get_span_expression(expr))
+                                                    span: error::position_to_span(expr.span())
                                                 });
                                             }
                                         });
                                     } else {
                                         unreachable!()
-                                        // self.error(
-                                        //     format!("Import `{imp}` has no functions named `{name}()`"),
-                                        //     *span
-                                        // );
                                     };
                                 }
-                                // Type::Enum(_, functions) => {},
                                 _ => {
                                     self.error(SemanticError::UnsupportedType {
                                         exception: format!("type `{prev_type}` isn't supported for method calls"),
@@ -2690,16 +2440,6 @@ impl<'s> Analyzer<'s> {
                                                 });
                                             }
                                         });
-
-                                        // let unassigned = assigned_fields.iter().filter(|x| !x.1).map(|x| x.0.to_owned().to_owned()).collect::<Vec<String>>();
-                                        // if !unassigned.is_empty() {
-                                        //     let fmt = format!("`{}`", unassigned.join("` , `"));
-                                        //     self.error(
-                                        //         format!("Missing structure fields: {fmt}"),
-                                        //         *span
-                                        //     );
-                                        // }
-
                                         prev_type_display = Type::Alias(static_name);
                                         prev_type = import.structs.get(static_name).unwrap().clone();
                                     }
@@ -2795,15 +2535,12 @@ impl<'s> Analyzer<'s> {
                                     ),
                                     help: None,
                                     src: self.source.clone(),
-                                    span: error::position_to_span(Parser::get_span_expression(
-                                        &arguments[ind].clone(),
-                                    )),
+                                    span: error::position_to_span(arguments[ind].span()),
                                 });
                             }
                         },
                     );
 
-                    // yeah, i know this looks like a shit, but i need it
                     if let Type::Pointer(func_ptr_type) = *func_type.clone() {
                         if let (Some(Type::Pointer(expected_ptr_type)), true) =
                             (expected.clone(), *func_ptr_type == Type::Void)
@@ -2927,7 +2664,7 @@ impl<'s> Analyzer<'s> {
                             ),
                             help: None,
                             src: self.source.clone(),
-                            span: error::position_to_span(Parser::get_span_expression(val)),
+                            span: error::position_to_span(val.span()),
                         });
                     }
                 });
@@ -2976,9 +2713,7 @@ impl<'s> Analyzer<'s> {
                                     exception: "tuple index must be unsigned".to_string(),
                                     help: None,
                                     src: self.source.clone(),
-                                    span: error::position_to_span(Parser::get_span_expression(
-                                        index,
-                                    )),
+                                    span: error::position_to_span(index.span()),
                                 });
 
                                 return expected.unwrap_or(Type::Void);
@@ -2993,7 +2728,7 @@ impl<'s> Analyzer<'s> {
                                         .to_string(),
                                 ),
                                 src: self.source.clone(),
-                                span: error::position_to_span(Parser::get_span_expression(index)),
+                                span: error::position_to_span(index.span()),
                             });
 
                             expected.unwrap_or(Type::Void)
@@ -3095,11 +2830,6 @@ impl<'s> Analyzer<'s> {
                     fields.iter().for_each(|field| {
                         let struct_field = struct_fields.get(field.0);
                         if let Some(field_type) = struct_field {
-                            // let field_type = self.unwrap_alias(field_type).unwrap_or_else(|err| {
-                            //     self.error(err, *span);
-                            //     Type::Void
-                            // });
-
                             let field_type = field_type.clone();
                             let provided_type = self.visit_expression(
                                 field.1,
@@ -3614,8 +3344,6 @@ impl<'s> Analyzer<'s> {
         let path = path.as_ref();
 
         if path.starts_with('@') {
-            // standard library path
-
             let genpaylib_env = std::env::var(STANDARD_LIBRARY_VAR)?;
             let expanded_stdlib_path = shellexpand::full(&genpaylib_env)?;
             let mut path_buffer = PathBuf::from(expanded_stdlib_path.as_ref());
@@ -3633,7 +3361,6 @@ impl<'s> Analyzer<'s> {
             path_buffer.push(module_path);
             Ok(path_buffer)
         } else {
-            // relative library path
             Ok(PathBuf::from(path))
         }
     }

--- a/genpay-semantic/src/macros/format.rs
+++ b/genpay-semantic/src/macros/format.rs
@@ -1,10 +1,10 @@
 use super::MacroObject;
 use crate::{
-    Analyzer,
     error::{self, SemanticError},
+    Analyzer,
 };
 use bumpalo::Bump;
-use genpay_parser::{expressions::Expressions, types::Type, value::Value};
+use genpay_parser::{expressions::{Expressions, Spannable}, types::Type, value::Value};
 
 /// **Formats literal and args into single string**
 /// `format!(LITERAL, ...)` -> `*char`
@@ -104,7 +104,7 @@ impl<'s> MacroObject<'s> for FormatMacro {
                                     exception: format!("type `{expr_type}` has wrong implementation for display"),
                                     help: Some(format!("Consider using right format: {DISPLAY_IMPLEMENTATION_FORMAT}")),
                                     src: analyzer.source.clone(),
-                                    span: error::position_to_span(genpay_parser::Parser::get_span_expression(expr))
+                                    span: error::position_to_span(expr.span())
                                 }
                             );
                         }
@@ -114,7 +114,7 @@ impl<'s> MacroObject<'s> for FormatMacro {
                                 exception: format!("type `{expr_type}` has no implementation for display"),
                                 help: Some(format!("Consider implementing necessary method: {DISPLAY_IMPLEMENTATION_FORMAT}")),
                                 src: analyzer.source.clone(),
-                                span: error::position_to_span(genpay_parser::Parser::get_span_expression(expr))
+                                span: error::position_to_span(expr.span())
                             }
                         );
                     }
@@ -132,7 +132,7 @@ impl<'s> MacroObject<'s> for FormatMacro {
                                         exception: format!("type `{expr_type}` has wrong implementation for display"),
                                         help: Some(format!("Consider using right format: {DISPLAY_IMPLEMENTATION_FORMAT}")),
                                         src: analyzer.source.clone(),
-                                        span: error::position_to_span(genpay_parser::Parser::get_span_expression(expr))
+                                        span: error::position_to_span(expr.span())
                                     }
                                 );
                             }
@@ -142,7 +142,7 @@ impl<'s> MacroObject<'s> for FormatMacro {
                                 exception: format!("type `{expr_type}` has no implementation for display"),
                                 help: Some(format!("Consider implementing necessary method: {DISPLAY_IMPLEMENTATION_FORMAT}")),
                                 src: analyzer.source.clone(),
-                                span: error::position_to_span(genpay_parser::Parser::get_span_expression(expr))
+                                span: error::position_to_span(expr.span())
                             }
                         );
                         }
@@ -151,7 +151,7 @@ impl<'s> MacroObject<'s> for FormatMacro {
                             exception: format!("no displayable type `{expr_type}` found"),
                             help: None,
                             src: analyzer.source.clone(),
-                            span: error::position_to_span(genpay_parser::Parser::get_span_expression(expr))
+                            span: error::position_to_span(expr.span())
                         });
                     }
                 }
@@ -161,7 +161,7 @@ impl<'s> MacroObject<'s> for FormatMacro {
                         exception: format!("type `{expr_type}` is not supported for display"),
                         help: None,
                         src: analyzer.source.clone(),
-                        span: error::position_to_span(genpay_parser::Parser::get_span_expression(expr))
+                        span: error::position_to_span(expr.span())
                     });
                 }
             }


### PR DESCRIPTION
Refactor Expressions to use TokenType for operators

This commit refactors the `Expressions` enum to use the `TokenType` enum for operators instead of string literals. This improves type safety and makes the code more robust.

The `Spannable` trait has been introduced to provide a consistent way of getting the span of an AST node. The `PartialEq` implementation for `Expressions` is now derived.

This change also includes fixes for the `genpay-semantic` and `genpay-codegen` crates, which were affected by the refactoring.
