### PR TITLE
refactor(lexer): Improve performance, features, and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,8 @@ name = "genpay-lexer"
 version = "0.0.1"
 dependencies = [
  "miette",
+ "phf",
+ "phf_codegen",
  "thiserror 2.0.14",
 ]
 
@@ -502,6 +504,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +578,21 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_users"
@@ -581,6 +650,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "strsim"

--- a/genpay-lexer/Cargo.toml
+++ b/genpay-lexer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "genpay-lexer"
 description = "Lexical Analyzer for Genpay Programming Language"
+build = "build.rs"
 
 version.workspace = true
 edition.workspace = true
@@ -9,3 +10,7 @@ authors.workspace = true
 [dependencies]
 miette = { version = "7.5.0", features = ["fancy"] }
 thiserror = "2.0.12"
+phf = { version = "0.11", features = ["macros"] }
+
+[build-dependencies]
+phf_codegen = "0.11"

--- a/genpay-lexer/build.rs
+++ b/genpay-lexer/build.rs
@@ -1,0 +1,50 @@
+use phf_codegen::Map;
+use std::env;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+fn main() {
+    let path = Path::new(&env::var("OUT_DIR").unwrap()).join("keywords.rs");
+    let mut file = BufWriter::new(File::create(&path).unwrap());
+
+    writeln!(
+        &mut file,
+        "static KEYWORDS: phf::Map<&'static str, TokenType> = {}",
+        Map::new()
+            .entry("let", "TokenType::Keyword")
+            .entry("pub", "TokenType::Keyword")
+            .entry("fn", "TokenType::Keyword")
+            .entry("import", "TokenType::Keyword")
+            .entry("include", "TokenType::Keyword")
+            .entry("extern", "TokenType::Keyword")
+            .entry("return", "TokenType::Keyword")
+            .entry("struct", "TokenType::Keyword")
+            .entry("enum", "TokenType::Keyword")
+            .entry("typedef", "TokenType::Keyword")
+            .entry("if", "TokenType::Keyword")
+            .entry("else", "TokenType::Keyword")
+            .entry("while", "TokenType::Keyword")
+            .entry("for", "TokenType::Keyword")
+            .entry("break", "TokenType::Keyword")
+            .entry("true", "TokenType::Boolean")
+            .entry("false", "TokenType::Boolean")
+            .entry("NULL", "TokenType::Null")
+            .entry("i8", "TokenType::Type")
+            .entry("i16", "TokenType::Type")
+            .entry("i32", "TokenType::Type")
+            .entry("i64", "TokenType::Type")
+            .entry("u8", "TokenType::Type")
+            .entry("u16", "TokenType::Type")
+            .entry("u32", "TokenType::Type")
+            .entry("u64", "TokenType::Type")
+            .entry("usize", "TokenType::Type")
+            .entry("f32", "TokenType::Type")
+            .entry("f64", "TokenType::Type")
+            .entry("bool", "TokenType::Type")
+            .entry("char", "TokenType::Type")
+            .entry("void", "TokenType::Type")
+            .build()
+    ).unwrap();
+    writeln!(&mut file, ";").unwrap();
+}

--- a/genpay-lexer/src/error.rs
+++ b/genpay-lexer/src/error.rs
@@ -58,13 +58,46 @@ pub enum LexerError {
     },
 
     #[error("Unknown character found: '{character}'")]
-    #[diagnostic(severity(Error), code(genpay::lexer::unknown))]
+    #[diagnostic(
+        severity(Error),
+        code(genpay::lexer::unknown),
+        help("Context: ...{context}...")
+    )]
     UnknownCharacter {
         character: char,
+        context: String,
 
         #[source_code]
         src: NamedSource<String>,
         #[label("unsupported character")]
+        span: SourceSpan,
+    },
+
+    #[error("Unterminated string literal")]
+    #[diagnostic(severity(Error), code(genpay::lexer::unterminated_string))]
+    UnterminatedString {
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("string starts here but is not closed")]
+        span: SourceSpan,
+    },
+
+    #[error("Unterminated block comment")]
+    #[diagnostic(severity(Error), code(genpay::lexer::unterminated_block_comment))]
+    UnterminatedBlockComment {
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("comment starts here but is not closed")]
+        span: SourceSpan,
+    },
+
+    #[error("Invalid number format: {message}")]
+    #[diagnostic(severity(Error), code(genpay::lexer::invalid_number_format))]
+    InvalidNumberFormat {
+        message: String,
+        #[source_code]
+        src: NamedSource<String>,
+        #[label("{message}")]
         span: SourceSpan,
     },
 }

--- a/genpay-lexer/src/lib.rs
+++ b/genpay-lexer/src/lib.rs
@@ -5,6 +5,12 @@ use crate::{
 };
 use miette::NamedSource;
 
+include!(concat!(env!("OUT_DIR"), "/keywords.rs"));
+
+fn is_valid_escape(b: u8) -> bool {
+    matches!(b, b'n' | b't' | b'r' | b'\\' | b'\'' | b'"' | b'0')
+}
+
 /// Error Handling Module
 pub mod error;
 /// Token Object and Implementations
@@ -34,6 +40,9 @@ impl<'s> Lexer<'s> {
     fn peek(&self) -> Option<u8> {
         self.src.as_bytes().get(self.cursor).copied()
     }
+    fn peek_next(&self) -> Option<u8> {
+        self.src.as_bytes().get(self.cursor + 1).copied()
+    }
     fn bump(&mut self) {
         self.cursor += 1;
     }
@@ -55,11 +64,6 @@ impl<'s> Lexer<'s> {
     {
         let start = self.cursor;
         while let Some(b) = self.peek() {
-            if b == b'\\' {
-                self.bump();
-                self.bump();
-                continue;
-            }
             if f(b) {
                 self.bump();
             } else {
@@ -69,7 +73,7 @@ impl<'s> Lexer<'s> {
         self.slice(start)
     }
 
-    fn eat_while_radix<F>(&mut self, _radix: u32, mut f: F) -> &'s str
+    fn eat_while_radix<F>(&mut self, mut f: F) -> &'s str
     where
         F: FnMut(u8) -> bool,
     {
@@ -92,83 +96,139 @@ impl<'s> Lexer<'s> {
             None => Ok(Token::new("", TokenType::EOF, (start, start))),
             Some(b'a'..=b'z' | b'A'..=b'Z' | b'_') => {
                 let ident = self.eat_while(|b| b.is_ascii_alphanumeric() || b == b'_');
-                let token_type = match ident {
-                    "let" => TokenType::Keyword,
-                    "pub" => TokenType::Keyword,
-                    "fn" => TokenType::Keyword,
-                    "import" => TokenType::Keyword,
-                    "include" => TokenType::Keyword,
-                    "extern" => TokenType::Keyword,
-                    "return" => TokenType::Keyword,
-                    "struct" => TokenType::Keyword,
-                    "enum" => TokenType::Keyword,
-                    "typedef" => TokenType::Keyword,
-                    "if" => TokenType::Keyword,
-                    "else" => TokenType::Keyword,
-                    "while" => TokenType::Keyword,
-                    "for" => TokenType::Keyword,
-                    "break" => TokenType::Keyword,
-                    "true" => TokenType::Boolean,
-                    "false" => TokenType::Boolean,
-                    "NULL" => TokenType::Null,
-                    "i8" => TokenType::Type,
-                    "i16" => TokenType::Type,
-                    "i32" => TokenType::Type,
-                    "i64" => TokenType::Type,
-                    "u8" => TokenType::Type,
-                    "u16" => TokenType::Type,
-                    "u32" => TokenType::Type,
-                    "u64" => TokenType::Type,
-                    "usize" => TokenType::Type,
-                    "f32" => TokenType::Type,
-                    "f64" => TokenType::Type,
-                    "bool" => TokenType::Type,
-                    "char" => TokenType::Type,
-                    "void" => TokenType::Type,
-                    _ => TokenType::Identifier,
-                };
+                let token_type = KEYWORDS.get(ident).cloned().unwrap_or(TokenType::Identifier);
                 Ok(Token::new(ident, token_type, (start, self.cursor)))
             }
             Some(b'0'..=b'9') => {
-                let num = self.eat_while_radix(10, |b| b.is_ascii_digit());
-                if self.peek() == Some(b'.') {
-                    self.bump();
-                    let frac = self.eat_while_radix(10, |b| b.is_ascii_digit());
-                    let mut value = String::from(num);
-                    value.push('.');
-                    value.push_str(frac);
-                    Ok(Token::new(
-                        self.slice(start),
-                        TokenType::FloatNumber,
-                        (start, self.cursor),
-                    ))
-                } else if self.peek() == Some(b'x') {
-                    self.bump();
-                    let _num = self.eat_while_radix(16, |b| b.is_ascii_hexdigit());
-                    Ok(Token::new(self.slice(start), TokenType::Number, (start, self.cursor)))
-                } else if self.peek() == Some(b'b') {
-                    self.bump();
-                    let _num = self.eat_while_radix(2, |b| b == b'0' || b == b'1');
-                    Ok(Token::new(self.slice(start), TokenType::Number, (start, self.cursor)))
-                } else {
-                    Ok(Token::new(num, TokenType::Number, (start, self.cursor)))
+                // Handle hex and binary first.
+                if self.src.as_bytes()[self.cursor] == b'0' {
+                    if self.peek_next() == Some(b'x') {
+                        self.bump(); // 0
+                        self.bump(); // x
+                        self.eat_while_radix(|b| b.is_ascii_hexdigit());
+                        return Ok(Token::new(self.slice(start), TokenType::Number, (start, self.cursor)));
+                    }
+                    if self.peek_next() == Some(b'b') {
+                        self.bump(); // 0
+                        self.bump(); // b
+                        self.eat_while_radix(|b| b == b'0' || b == b'1');
+                        return Ok(Token::new(self.slice(start), TokenType::Number, (start, self.cursor)));
+                    }
                 }
+
+                // Now decimal numbers (int or float)
+                self.eat_while_radix(|b| b.is_ascii_digit());
+                let mut is_float = false;
+
+                if self.peek() == Some(b'.') {
+                    // check that it's not `.` followed by a non-digit
+                    if self.src.as_bytes().get(self.cursor + 1).map_or(false, |c| c.is_ascii_digit()) {
+                        is_float = true;
+                        self.bump(); // consume '.'
+                        self.eat_while_radix(|b| b.is_ascii_digit());
+                    }
+                }
+
+                if self.peek() == Some(b'e') || self.peek() == Some(b'E') {
+                    is_float = true;
+                    self.bump(); // consume 'e' or 'E'
+                    if self.peek() == Some(b'+') || self.peek() == Some(b'-') {
+                        self.bump(); // consume sign
+                    }
+                    let exponent_digits = self.eat_while_radix(|b| b.is_ascii_digit());
+                    if exponent_digits.is_empty() {
+                        return Err(LexerError::InvalidNumberFormat {
+                            message: "Missing exponent digits".to_string(),
+                            src: NamedSource::new(self.filename, self.src.to_string()),
+                            span: (self.cursor, 1).into(),
+                        });
+                    }
+                }
+
+                let token_type = if is_float { TokenType::FloatNumber } else { TokenType::Number };
+                Ok(Token::new(self.slice(start), token_type, (start, self.cursor)))
             }
             Some(b'"') => {
                 self.bump(); // opening quote
-                let lit = self.eat_while(|b| b != b'"');
-                if self.peek() == Some(b'"') {
-                    self.bump();
+                let content_start = self.cursor;
+                loop {
+                    match self.peek() {
+                        Some(b'\\') => {
+                            self.bump(); // consume '\'
+                            if let Some(b) = self.peek() {
+                                if is_valid_escape(b) {
+                                    self.bump();
+                                } else {
+                                    return Err(LexerError::UnknownCharacterEscape {
+                                        escape: (b as char).to_string(),
+                                        src: NamedSource::new(self.filename, self.src.to_string()),
+                                        span: (self.cursor, 1).into(),
+                                    });
+                                }
+                            } else {
+                                return Err(LexerError::UnterminatedString {
+                                    src: NamedSource::new(self.filename, self.src.to_string()),
+                                    span: (start, self.cursor - start).into(),
+                                });
+                            }
+                        }
+                        Some(b'"') => {
+                            let content = &self.src[content_start..self.cursor];
+                            self.bump(); // closing quote
+                            return Ok(Token::new(content, TokenType::String, (start, self.cursor)));
+                        }
+                        Some(_) => {
+                            self.bump();
+                        }
+                        None => {
+                            return Err(LexerError::UnterminatedString {
+                                src: NamedSource::new(self.filename, self.src.to_string()),
+                                span: (start, self.cursor - start).into(),
+                            });
+                        }
+                    }
                 }
-                Ok(Token::new(lit, TokenType::String, (start, self.cursor)))
             }
             Some(b'\'') => {
                 self.bump(); // opening quote
-                let lit = self.eat_while(|b| b != b'\'');
-                if self.peek() == Some(b'\'') {
-                    self.bump();
+                let content_start = self.cursor;
+                loop {
+                    match self.peek() {
+                        Some(b'\\') => {
+                            self.bump(); // consume '\'
+                            if let Some(b) = self.peek() {
+                                if is_valid_escape(b) {
+                                    self.bump();
+                                } else {
+                                    return Err(LexerError::UnknownCharacterEscape {
+                                        escape: (b as char).to_string(),
+                                        src: NamedSource::new(self.filename, self.src.to_string()),
+                                        span: (self.cursor, 1).into(),
+                                    });
+                                }
+                            } else {
+                                return Err(LexerError::UnterminatedString {
+                                    src: NamedSource::new(self.filename, self.src.to_string()),
+                                    span: (start, self.cursor - start).into(),
+                                });
+                            }
+                        }
+                        Some(b'\'') => {
+                            let content = &self.src[content_start..self.cursor];
+                            self.bump(); // closing quote
+                            return Ok(Token::new(content, TokenType::Char, (start, self.cursor)));
+                        }
+                        Some(_) => {
+                            self.bump();
+                        }
+                        None => {
+                            return Err(LexerError::UnterminatedString {
+                                src: NamedSource::new(self.filename, self.src.to_string()),
+                                span: (start, self.cursor - start).into(),
+                            });
+                        }
+                    }
                 }
-                Ok(Token::new(lit, TokenType::Char, (start, self.cursor)))
             }
             Some(b'+') => {
                 self.bump();
@@ -185,7 +245,40 @@ impl<'s> Lexer<'s> {
             Some(b'/') => {
                 self.bump();
                 if self.peek() == Some(b'/') {
+                    // Single line comment
                     self.eat_while(|b| b != b'\n');
+                    self.next_token()
+                } else if self.peek() == Some(b'*') {
+                    // Block comment
+                    self.bump(); // consume '*'
+                    let mut depth = 1;
+                    while depth > 0 {
+                        match self.peek() {
+                            Some(b'*') => {
+                                self.bump();
+                                if self.peek() == Some(b'/') {
+                                    self.bump();
+                                    depth -= 1;
+                                }
+                            }
+                            Some(b'/') => {
+                                self.bump();
+                                if self.peek() == Some(b'*') {
+                                    self.bump();
+                                    depth += 1;
+                                }
+                            }
+                            Some(_) => {
+                                self.bump();
+                            }
+                            None => {
+                                return Err(LexerError::UnterminatedBlockComment {
+                                    src: NamedSource::new(self.filename, self.src.to_string()),
+                                    span: (start, self.cursor - start).into(),
+                                });
+                            }
+                        }
+                    }
                     self.next_token()
                 } else {
                     Ok(Token::new("/", TokenType::Divide, (start, self.cursor)))
@@ -301,8 +394,12 @@ impl<'s> Lexer<'s> {
             }
             Some(c) => {
                 self.bump();
+                let context_start = start.saturating_sub(20);
+                let context_end = (start + 20).min(self.src.len());
+                let context = self.src[context_start..context_end].to_string();
                 Err(LexerError::UnknownCharacter {
                     character: c as char,
+                    context,
                     src: NamedSource::new(self.filename, self.src.to_string()),
                     span: (start, 1).into(),
                 })
@@ -313,7 +410,7 @@ impl<'s> Lexer<'s> {
 
 #[cfg(test)]
 mod tests {
-    use super::{token::Token, token_type::TokenType, Lexer};
+    use super::{token::Token, token_type::TokenType, Lexer, error::LexerError};
 
     fn assert_tokens(lexer: &mut Lexer, expected: &[Token]) {
         for expected_token in expected {
@@ -582,6 +679,72 @@ mod tests {
             Token::new("=", TokenType::Equal, (20, 21)),
         ];
         assert_tokens(&mut lexer, &expected);
+    }
+
+    #[test]
+    fn block_comment() {
+        let input = "/* this is a block comment */ 123";
+        let mut lexer = Lexer::new(input, "test.genpay");
+        let expected = vec![
+            Token::new("123", TokenType::Number, (28, 31)),
+        ];
+        assert_tokens(&mut lexer, &expected);
+    }
+
+    #[test]
+    fn nested_block_comment() {
+        let input = "/* nested /* comment */ */ 123";
+        let mut lexer = Lexer::new(input, "test.genpay");
+        let expected = vec![
+            Token::new("123", TokenType::Number, (27, 30)),
+        ];
+        assert_tokens(&mut lexer, &expected);
+    }
+
+    #[test]
+    fn unterminated_block_comment_error() {
+        let input = "/* hello";
+        let mut lexer = Lexer::new(input, "test.genpay");
+        let result = lexer.next().unwrap();
+        assert!(matches!(result, Err(LexerError::UnterminatedBlockComment { .. })));
+    }
+
+    #[test]
+    fn exponent_numbers() {
+        let input = "1e5 1.23e4 1.23e+4 1.23E-4 1e-5";
+        let mut lexer = Lexer::new(input, "test.genpay");
+        let expected = vec![
+            Token::new("1e5", TokenType::FloatNumber, (0, 3)),
+            Token::new("1.23e4", TokenType::FloatNumber, (4, 10)),
+            Token::new("1.23e+4", TokenType::FloatNumber, (11, 18)),
+            Token::new("1.23E-4", TokenType::FloatNumber, (19, 26)),
+            Token::new("1e-5", TokenType::FloatNumber, (27, 31)),
+        ];
+        assert_tokens(&mut lexer, &expected);
+    }
+
+    #[test]
+    fn invalid_exponent_error() {
+        let input = "1e";
+        let mut lexer = Lexer::new(input, "test.genpay");
+        let result = lexer.next().unwrap();
+        assert!(matches!(result, Err(LexerError::InvalidNumberFormat { .. })));
+    }
+
+    #[test]
+    fn unterminated_string_error() {
+        let input = "\"hello";
+        let mut lexer = Lexer::new(input, "test.genpay");
+        let result = lexer.next().unwrap();
+        assert!(matches!(result, Err(LexerError::UnterminatedString { .. })));
+    }
+
+    #[test]
+    fn invalid_escape_sequence_error() {
+        let input = "\"\\z\"";
+        let mut lexer = Lexer::new(input, "test.genpay");
+        let result = lexer.next().unwrap();
+        assert!(matches!(result, Err(LexerError::UnknownCharacterEscape { .. })));
     }
 }
 

--- a/genpay-lexer/src/token.rs
+++ b/genpay-lexer/src/token.rs
@@ -1,6 +1,6 @@
 use crate::token_type::TokenType;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Token<'s> {
     pub value: &'s str,
     pub token_type: TokenType,


### PR DESCRIPTION
This commit introduces a significant refactoring of the `genpay-lexer` crate, addressing several areas for improvement.

- Replaced the keyword `match` statement with a `phf::Map` for more efficient keyword lookups. A build script is used to generate the map at compile time.

- Removed the unused `radix` parameter from the `eat_while_radix` function.

- Added the `Copy` trait to the `Token` struct, as all its fields are `Copy`-able, which can improve performance.

- Implemented proper handling of escape sequences in string and character literals. The lexer now validates escape sequences and reports an error for invalid ones.

- Added support for nested block comments (`/* ... */`), in addition to single-line comments (`//`).

- Extended the number parsing logic to support scientific notation with exponents (e.g., `1.23e+4`, `5.0E-10`).

- Enhanced error reporting for unknown characters to include a contextual snippet of the source code in the error message, leveraging `miette`'s diagnostic capabilities.

- Added a comprehensive set of new tests to verify the new functionality, including block comments, exponent parsing, and various error conditions.