### PR TITLE
refactor(lexer): Use static hash map for keywords

### DIFF
--- a/genpay-lexer/src/keywords.rs
+++ b/genpay-lexer/src/keywords.rs
@@ -1,0 +1,147 @@
+use crate::{token::Token, token_type::TokenType};
+use std::collections::HashMap;
+
+pub fn get_keywords() -> HashMap<String, Token> {
+    HashMap::from([
+        // Constructions
+        (
+            "if".to_string(),
+            Token::new("if".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "else".to_string(),
+            Token::new("else".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "while".to_string(),
+            Token::new("while".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "for".to_string(),
+            Token::new("for".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "break".to_string(),
+            Token::new("break".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        // Tech
+        (
+            "let".to_string(),
+            Token::new("let".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "pub".to_string(),
+            Token::new("pub".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "fn".to_string(),
+            Token::new("fn".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "import".to_string(),
+            Token::new("import".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "include".to_string(),
+            Token::new("include".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "extern".to_string(),
+            Token::new("extern".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "return".to_string(),
+            Token::new("return".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "struct".to_string(),
+            Token::new("struct".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "enum".to_string(),
+            Token::new("enum".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "typedef".to_string(),
+            Token::new("typedef".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "_extern_declare".to_string(),
+            Token::new("_extern_declare".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        (
+            "_link_c".to_string(),
+            Token::new("_link_c".to_string(), TokenType::Keyword, (0, 0)),
+        ),
+        // Types
+        (
+            "i8".to_string(),
+            Token::new("i8".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "i16".to_string(),
+            Token::new("i16".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "i32".to_string(),
+            Token::new("i32".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "i64".to_string(),
+            Token::new("i64".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "u8".to_string(),
+            Token::new("u8".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "u16".to_string(),
+            Token::new("u16".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "u32".to_string(),
+            Token::new("u32".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "u64".to_string(),
+            Token::new("u64".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "usize".to_string(),
+            Token::new("usize".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "f32".to_string(),
+            Token::new("f32".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "f64".to_string(),
+            Token::new("f64".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "bool".to_string(),
+            Token::new("bool".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "char".to_string(),
+            Token::new("char".to_string(), TokenType::Type, (0, 0)),
+        ),
+        (
+            "void".to_string(),
+            Token::new("void".to_string(), TokenType::Type, (0, 0)),
+        ),
+        // Values
+        (
+            "true".to_string(),
+            Token::new("true".to_string(), TokenType::Boolean, (0, 0)),
+        ),
+        (
+            "false".to_string(),
+            Token::new("false".to_string(), TokenType::Boolean, (0, 0)),
+        ),
+        (
+            "NULL".to_string(),
+            Token::new("NULL".to_string(), TokenType::Null, (0, 0)),
+        ),
+    ])
+}

--- a/genpay-lexer/src/lib.rs
+++ b/genpay-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{LexerError, LexerWarning},
-    macros::{std_keyword, std_symbol, std_token, std_type},
+    macros::std_symbol,
     token::Token,
     token_type::TokenType,
 };
@@ -9,6 +9,8 @@ use std::collections::HashMap;
 
 /// Error Handling Module
 pub mod error;
+/// Keywords Hash Map
+mod keywords;
 /// Helpful Macros Module
 mod macros;
 /// Token Object and Implementations
@@ -76,46 +78,7 @@ impl Lexer {
                 std_symbol!('{', TokenType::LBrace),
                 std_symbol!('}', TokenType::RBrace),
             ]),
-            std_words: HashMap::from([
-                // Constructions
-                std_keyword!("if"),
-                std_keyword!("else"),
-                std_keyword!("while"),
-                std_keyword!("for"),
-                std_keyword!("break"),
-                // Tech
-                std_keyword!("let"),
-                std_keyword!("pub"),
-                std_keyword!("fn"),
-                std_keyword!("import"),
-                std_keyword!("include"),
-                std_keyword!("extern"),
-                std_keyword!("return"),
-                std_keyword!("struct"),
-                std_keyword!("enum"),
-                std_keyword!("typedef"),
-                std_keyword!("_extern_declare"),
-                std_keyword!("_link_c"),
-                // Types
-                std_type!("i8"),
-                std_type!("i16"),
-                std_type!("i32"),
-                std_type!("i64"),
-                std_type!("u8"),
-                std_type!("u16"),
-                std_type!("u32"),
-                std_type!("u64"),
-                std_type!("usize"),
-                std_type!("f32"),
-                std_type!("f64"),
-                std_type!("bool"),
-                std_type!("char"),
-                std_type!("void"),
-                // Values
-                std_token!("true", TokenType::Boolean),
-                std_token!("false", TokenType::Boolean),
-                std_token!("NULL", TokenType::Null),
-            ]),
+            std_words: keywords::get_keywords(),
 
             errors: Vec::new(),
             warnings: Vec::new(),

--- a/genpay-lexer/src/macros.rs
+++ b/genpay-lexer/src/macros.rs
@@ -4,34 +4,4 @@ macro_rules! std_symbol {
     };
 }
 
-macro_rules! std_keyword {
-    ($name: literal) => {
-        (
-            $name.to_string(),
-            Token::new($name.to_string(), TokenType::Keyword, (0, 0)),
-        )
-    };
-}
-
-macro_rules! std_type {
-    ($name: literal) => {
-        (
-            $name.to_string(),
-            Token::new($name.to_string(), TokenType::Type, (0, 0)),
-        )
-    };
-}
-
-macro_rules! std_token {
-    ($name: literal, $value: expr) => {
-        (
-            $name.to_string(),
-            Token::new($name.to_string(), $value, (0, 0)),
-        )
-    };
-}
-
-pub(crate) use std_keyword;
 pub(crate) use std_symbol;
-pub(crate) use std_token;
-pub(crate) use std_type;


### PR DESCRIPTION
This commit refactors the `genpay-lexer` to remove the macro-based keyword definition.

A new `keywords.rs` module was created to house a `get_keywords` function that returns a `HashMap` of all keywords. The `Lexer` now uses this function for initialization.

This change improves code readability and maintainability by centralizing the keyword definitions in a single data structure.