### PR TITLE
feat(lexer): Refactor lexer to be zero-allocation

### DIFF
--- a/genpay-lexer/src/error.rs
+++ b/genpay-lexer/src/error.rs
@@ -1,94 +1,30 @@
-use miette::{Diagnostic, NamedSource, SourceSpan};
-use thiserror::Error;
-
-/// Simple function to convert position range to miette span
-pub fn position_to_span(from: usize, to: usize) -> SourceSpan {
-    (from, to.wrapping_sub(from)).into()
-}
-
-#[derive(Debug, Error, Diagnostic, Clone, PartialEq, Eq)]
-pub enum LexerError {
-    #[error("Invalid number constant")]
-    #[diagnostic(
-        severity(Error),
-        code(genpay::lexer::invalid_constant),
-        help("Check the spelling of the constant")
-    )]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LexerError<'a> {
     InvalidNumberConstant {
-        const_type: String,
-
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("expected {const_type} constant")]
-        span: SourceSpan,
+        const_type: &'static str,
+        span: (usize, usize),
     },
 
-    #[error("Constant parser returned error: {parser_error}")]
-    #[diagnostic(severity(Error), code(genpay::lexer::constant_error))]
     ConstantParserError {
-        const_type: String,
-        parser_error: String,
-
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("constant type: {const_type}")]
-        span: SourceSpan,
+        const_type: &'static str,
+        span: (usize, usize),
     },
 
-    #[error("Unknown character escape: {escape}")]
-    #[diagnostic(
-        severity(Error),
-        code(genpay::lexer::literal_error),
-        help(
-            "If you meant to write a literal backslash, consider using its double version: '\\\\'"
-        )
-    )]
     UnknownCharacterEscape {
-        escape: String,
-
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("unknown character escape literal")]
-        span: SourceSpan,
+        escape: &'a str,
+        span: (usize, usize),
     },
 
-    #[error("Unknown character found: '{character}'")]
-    #[diagnostic(severity(Error), code(genpay::lexer::unknown))]
     UnknownCharacter {
         character: char,
-
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("unsupported character")]
-        span: SourceSpan,
-    },
-}
-
-#[derive(Debug, Error, Diagnostic, Clone, PartialEq, Eq)]
-pub enum LexerWarning {
-    #[error("Extra zeros in constant")]
-    #[diagnostic(
-        severity(Warning),
-        code(genpay::lexer::extra_zeros),
-        help("Consider removing unnecessary zeros")
-    )]
-    ExtraZeros {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("extra zeros here")]
-        span: SourceSpan,
+        span: (usize, usize),
     },
 
-    #[error("Extra zeros in floating number")]
-    #[diagnostic(
-        severity(Warning),
-        code(genpay::lexer::extra_float_zeros),
-        help("Consider removing unnecessary zeros")
-    )]
-    ExtraFloatZeros {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("extra zeros at the end")]
-        span: SourceSpan,
+    UnterminatedString {
+        span: (usize, usize),
+    },
+
+    UnterminatedChar {
+        span: (usize, usize),
     },
 }

--- a/genpay-lexer/src/token.rs
+++ b/genpay-lexer/src/token.rs
@@ -1,14 +1,14 @@
 use crate::token_type::TokenType;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Token {
-    pub value: String,
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Token<'a> {
+    pub value: &'a str,
     pub token_type: TokenType,
     pub span: (usize, usize),
 }
 
-impl Token {
-    pub fn new(value: String, token_type: TokenType, span: (usize, usize)) -> Self {
+impl<'a> Token<'a> {
+    pub fn new(value: &'a str, token_type: TokenType, span: (usize, usize)) -> Self {
         Self {
             value,
             token_type,

--- a/genpay-lexer/src/token_type.rs
+++ b/genpay-lexer/src/token_type.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum TokenType {
     Identifier, // abc
     Keyword,    // let


### PR DESCRIPTION
This commit refactors the `genpay-lexer` crate to be a zero-allocation lexer. The previous implementation relied heavily on heap allocations with `String`, `Vec`, and `HashMap`.

The new implementation introduces the following changes:

- The `Lexer` is now an `Iterator`, which processes the input stream on-demand without collecting all tokens into a `Vec`.
- The `Lexer` struct now holds a string slice (`&'a str`) for the source code and a cursor, instead of owning a `String` and a `Vec<char>`.
- The `Token` struct has been updated to use a string slice (`&'a str`) for its value, pointing directly to the source code, thus avoiding allocations for each token's value.
- The `TokenType` and `Token` structs now derive `Copy` for better performance.
- The `HashMap` used for keyword lookup has been replaced with a `lookup_identifier` function that uses a `match` statement, which is more efficient and allocation-free.
- The `LexerError` enum has been simplified and refactored to be allocation-free, removing the dependency on `miette` within the lexer's core error types.
- The tests have been rewritten to work with the new iterator-based API.

This change significantly improves the performance and memory efficiency of the lexer.