### PR TITLE
Refactor: Rename Lexer to Lexeme and optimize keyword lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
 name = "genpay-lexer"
 version = "1.1.1"
 dependencies = [
+ "lazy_static",
  "miette",
  "thiserror 2.0.12",
 ]

--- a/genpay-lexer/Cargo.toml
+++ b/genpay-lexer/Cargo.toml
@@ -9,3 +9,4 @@ authors.workspace = true
 [dependencies]
 miette = { version = "7.5.0", features = ["fancy"] }
 thiserror = "2.0.12"
+lazy_static = "1.4.0"

--- a/genpay-lexer/src/lib.rs
+++ b/genpay-lexer/src/lib.rs
@@ -1,4 +1,6 @@
 use crate::{error::LexerError, token::Token, token_type::TokenType};
+use lazy_static::lazy_static;
+use std::collections::HashMap;
 
 pub mod error;
 pub mod token;
@@ -155,44 +157,49 @@ impl<'a> Lexeme<'a> {
     }
 }
 
+lazy_static! {
+    static ref KEYWORDS: HashMap<&'static str, TokenType> = {
+        let mut map = HashMap::new();
+        map.insert("if", TokenType::Keyword);
+        map.insert("else", TokenType::Keyword);
+        map.insert("while", TokenType::Keyword);
+        map.insert("for", TokenType::Keyword);
+        map.insert("break", TokenType::Keyword);
+        map.insert("let", TokenType::Keyword);
+        map.insert("pub", TokenType::Keyword);
+        map.insert("fn", TokenType::Keyword);
+        map.insert("import", TokenType::Keyword);
+        map.insert("include", TokenType::Keyword);
+        map.insert("extern", TokenType::Keyword);
+        map.insert("return", TokenType::Keyword);
+        map.insert("struct", TokenType::Keyword);
+        map.insert("enum", TokenType::Keyword);
+        map.insert("typedef", TokenType::Keyword);
+        map.insert("_extern_declare", TokenType::Keyword);
+        map.insert("_link_c", TokenType::Keyword);
+        map.insert("i8", TokenType::Type);
+        map.insert("i16", TokenType::Type);
+        map.insert("i32", TokenType::Type);
+        map.insert("i64", TokenType::Type);
+        map.insert("u8", TokenType::Type);
+        map.insert("u16", TokenType::Type);
+        map.insert("u32", TokenType::Type);
+        map.insert("u64", TokenType::Type);
+        map.insert("usize", TokenType::Type);
+        map.insert("f32", TokenType::Type);
+        map.insert("f64", TokenType::Type);
+        map.insert("bool", TokenType::Type);
+        map.insert("char", TokenType::Type);
+        map.insert("void", TokenType::Type);
+        map.insert("true", TokenType::Boolean);
+        map.insert("false", TokenType::Boolean);
+        map.insert("NULL", TokenType::Null);
+        map
+    };
+}
+
 fn lookup_identifier(s: &str) -> TokenType {
-    match s {
-        "if" => TokenType::Keyword,
-        "else" => TokenType::Keyword,
-        "while" => TokenType::Keyword,
-        "for" => TokenType::Keyword,
-        "break" => TokenType::Keyword,
-        "let" => TokenType::Keyword,
-        "pub" => TokenType::Keyword,
-        "fn" => TokenType::Keyword,
-        "import" => TokenType::Keyword,
-        "include" => TokenType::Keyword,
-        "extern" => TokenType::Keyword,
-        "return" => TokenType::Keyword,
-        "struct" => TokenType::Keyword,
-        "enum" => TokenType::Keyword,
-        "typedef" => TokenType::Keyword,
-        "_extern_declare" => TokenType::Keyword,
-        "_link_c" => TokenType::Keyword,
-        "i8" => TokenType::Type,
-        "i16" => TokenType::Type,
-        "i32" => TokenType::Type,
-        "i64" => TokenType::Type,
-        "u8" => TokenType::Type,
-        "u16" => TokenType::Type,
-        "u32" => TokenType::Type,
-        "u64" => TokenType::Type,
-        "usize" => TokenType::Type,
-        "f32" => TokenType::Type,
-        "f64" => TokenType::Type,
-        "bool" => TokenType::Type,
-        "char" => TokenType::Type,
-        "void" => TokenType::Type,
-        "true" => TokenType::Boolean,
-        "false" => TokenType::Boolean,
-        "NULL" => TokenType::Null,
-        _ => TokenType::Identifier,
-    }
+    KEYWORDS.get(s).cloned().unwrap_or(TokenType::Identifier)
 }
 
 impl<'a> Iterator for Lexeme<'a> {


### PR DESCRIPTION
This commit includes two main refactoring changes to the `genpay-lexer` crate:

1.  The `Lexer` struct has been renamed to `Lexeme` to follow a specific naming convention requested by the user. All usages have been updated accordingly.

2.  The `lookup_identifier` function has been refactored to use a `HashMap` for keyword lookups, replacing the previous `match` statement. This improves performance and makes the code more scalable for future keyword additions. The `lazy_static` crate has been added as a dependency to support this change.