### PR TITLE
feat: Replace indexmap with BTreeMap

### DIFF
--- a/genpay-lexer/src/lib.rs
+++ b/genpay-lexer/src/lib.rs
@@ -513,20 +513,22 @@ mod tests {
         let lexer = Lexer::new(input);
         let tokens: Vec<_> = lexer.collect::<Result<_, _>>().unwrap();
 
+        // NOTE: The original test data had incorrect values for some tokens (e.g. "%.").
+        // This has been corrected to match the expected output of the lexer.
         let expected_tokens = vec![
             Token::new("+".to_string(), TokenType::Plus, (0, 1)),
             Token::new("-".to_string(), TokenType::Minus, (2, 1)),
             Token::new("*".to_string(), TokenType::Multiply, (4, 1)),
             Token::new("/".to_string(), TokenType::Divide, (6, 1)),
-            Token::new("%.".to_string(), TokenType::Modulus, (8, 1)),
+            Token::new("%".to_string(), TokenType::Modulus, (8, 1)),
             Token::new("=".to_string(), TokenType::Equal, (10, 1)),
-            Token::new("==.".to_string(), TokenType::Eq, (12, 2)),
+            Token::new("==".to_string(), TokenType::Eq, (12, 2)),
             Token::new("!=".to_string(), TokenType::Ne, (15, 2)),
-            Token::new("<.".to_string(), TokenType::Lt, (18, 1)),
+            Token::new("<".to_string(), TokenType::Lt, (18, 1)),
             Token::new(">".to_string(), TokenType::Bt, (20, 1)),
             Token::new("<=".to_string(), TokenType::Leq, (22, 2)),
             Token::new(">=".to_string(), TokenType::Beq, (25, 2)),
-            Token::new("&&.".to_string(), TokenType::And, (28, 2)),
+            Token::new("&&".to_string(), TokenType::And, (28, 2)),
             Token::new("||".to_string(), TokenType::Or, (31, 2)),
             Token::new("!".to_string(), TokenType::Not, (34, 1)),
             Token::new("&".to_string(), TokenType::Ampersand, (36, 1)),

--- a/genpay-parser/Cargo.toml
+++ b/genpay-parser/Cargo.toml
@@ -11,4 +11,3 @@ license.workspace = true
 genpay-lexer = { path = "../genpay-lexer" }
 miette = { version = "7.5.0", features = ["fancy"] }
 thiserror = "2.0.12"
-indexmap = "2.9.0"

--- a/genpay-parser/src/lib.rs
+++ b/genpay-parser/src/lib.rs
@@ -642,8 +642,8 @@ impl Parser {
         }
         self.next_token();
 
-        let mut fields = indexmap::IndexMap::new();
-        let mut functions: indexmap::IndexMap<String, Vec<Statements>> = indexmap::IndexMap::new();
+        let mut fields = std::collections::BTreeMap::new();
+        let mut functions: std::collections::BTreeMap<String, Vec<Statements>> = std::collections::BTreeMap::new();
 
         while self.current_token.token_type != TokenType::RBrace
             && self.current_token.token_type != TokenType::EOF
@@ -730,8 +730,8 @@ impl Parser {
         self.next_token();
 
         let mut fields = vec![];
-        let mut functions: indexmap::IndexMap<String, Vec<Statements>> =
-            indexmap::IndexMap::new();
+        let mut functions: std::collections::BTreeMap<String, Vec<Statements>> =
+            std::collections::BTreeMap::new();
 
         while self.current_token.token_type != TokenType::RBrace
             && self.current_token.token_type != TokenType::EOF

--- a/genpay-parser/src/statements.rs
+++ b/genpay-parser/src/statements.rs
@@ -1,5 +1,5 @@
 use crate::{expressions::Expressions, types::Type};
-use indexmap::IndexMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statements {
@@ -83,8 +83,8 @@ pub enum Statements {
     /// ```
     StructDefineStatement {
         name: String,
-        fields: IndexMap<String, Type>,
-        functions: IndexMap<String, Vec<Statements>>,
+        fields: BTreeMap<String, Type>,
+        functions: BTreeMap<String, Vec<Statements>>,
         public: bool,
         span: (usize, usize),
     },
@@ -100,7 +100,7 @@ pub enum Statements {
     EnumDefineStatement {
         name: String,
         fields: Vec<String>,
-        functions: IndexMap<String, Vec<Statements>>,
+        functions: BTreeMap<String, Vec<Statements>>,
         public: bool,
         span: (usize, usize),
     },

--- a/genpay-parser/src/types.rs
+++ b/genpay-parser/src/types.rs
@@ -1,4 +1,4 @@
-use indexmap::IndexMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
@@ -35,8 +35,8 @@ pub enum Type {
 
     // for semantical analyzer
     Function(Vec<Type>, Box<Type>, bool), // fn foo(a: i32, b: u32) string  --->  Function([I32, U32], String)
-    Struct(IndexMap<String, Type>, IndexMap<String, Type>), // struct Abc { a: i32, b: bool, c: *u64 }  ---> Struct([I32, Bool, Pointer(U64)])
-    Enum(Vec<String>, IndexMap<String, Type>), // enum Abc { A, B, C } -> Enum([A, B, C])
+    Struct(BTreeMap<String, Type>, BTreeMap<String, Type>), // struct Abc { a: i32, b: bool, c: *u64 }  ---> Struct([I32, Bool, Pointer(U64)])
+    Enum(Vec<String>, BTreeMap<String, Type>), // enum Abc { A, B, C } -> Enum([A, B, C])
 
     ImportObject(String),
 }

--- a/genpay-semantic/Cargo.toml
+++ b/genpay-semantic/Cargo.toml
@@ -12,5 +12,4 @@ genpay-parser = { path = "../genpay-parser" }
 genpay-lexer = { path = "../genpay-lexer" }
 miette = { version = "7.5.0", features = ["fancy"] }
 thiserror = "2.0.12"
-indexmap = "2.9.0"
 shellexpand = "3.1.1"

--- a/genpay-semantic/src/visitor.rs
+++ b/genpay-semantic/src/visitor.rs
@@ -1,6 +1,6 @@
 use crate::{Analyzer, Scope, SemanticError};
 use genpay_parser::{expressions::Expressions, statements::Statements, types::Type};
-use indexmap::IndexMap;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 impl Analyzer {
@@ -189,7 +189,7 @@ impl Analyzer {
                 public,
                 span,
             } => {
-                let struct_type = Type::Struct(fields.clone(), IndexMap::new());
+                let struct_type = Type::Struct(fields.clone(), BTreeMap::new());
 
                 if let Err(err) = self.scope.add_struct(name.clone(), struct_type, *public) {
                     self.error(SemanticError::RedefinitionError {
@@ -207,7 +207,7 @@ impl Analyzer {
                 public,
                 span,
             } => {
-                let enum_type = Type::Enum(fields.clone(), IndexMap::new());
+                let enum_type = Type::Enum(fields.clone(), BTreeMap::new());
 
                 if let Err(err) = self.scope.add_enum(name.clone(), enum_type, *public) {
                     self.error(SemanticError::RedefinitionError {


### PR DESCRIPTION
This commit replaces the `indexmap` crate with `std::collections::BTreeMap` across the codebase to reduce dependencies.

The following changes were made:
- Removed the `indexmap` dependency from `genpay-parser/Cargo.toml` and `genpay-semantic/Cargo.toml`.
- Replaced `indexmap::IndexMap` with `std::collections::BTreeMap` in `genpay-parser` and `genpay-semantic`.

Additionally, a bug in the `operators` test in `genpay-lexer` was fixed. The original test data contained incorrect token values, which caused the test to fail. This fix was necessary to ensure that all tests pass after the dependency replacement.