### PR TITLE
refactor: Use Cow<'a, str> in lexer and parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,12 +240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +302,6 @@ name = "genpay-parser"
 version = "1.1.1"
 dependencies = [
  "genpay-lexer",
- "indexmap",
  "miette",
  "thiserror 2.0.12",
 ]
@@ -319,7 +312,6 @@ version = "1.1.1"
 dependencies = [
  "genpay-lexer",
  "genpay-parser",
- "indexmap",
  "miette",
  "shellexpand",
  "thiserror 2.0.12",
@@ -343,26 +335,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "hashbrown"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "indexmap"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "inkwell"

--- a/genpay-lexer/src/lib.rs
+++ b/genpay-lexer/src/lib.rs
@@ -6,13 +6,13 @@ pub mod error;
 pub mod token;
 pub mod token_type;
 
-pub struct Lexer {
-    source: String,
+pub struct Lexer<'a> {
+    source: &'a str,
     cursor: usize,
 }
 
-impl Lexer {
-    pub fn new(source: String) -> Self {
+impl<'a> Lexer<'a> {
+    pub fn new(source: &'a str) -> Self {
         Lexer { source, cursor: 0 }
     }
 
@@ -21,9 +21,7 @@ impl Lexer {
     }
 
     fn peek(&self) -> Option<char> {
-        self.source
-            .get(self.cursor..)
-            .and_then(|s| s.chars().next())
+        self.source.get(self.cursor..).and_then(|s| s.chars().next())
     }
 
     fn advance(&mut self) -> Option<char> {
@@ -48,9 +46,9 @@ impl Lexer {
         token_type: TokenType,
         start: usize,
         len: usize,
-    ) -> Result<Token, LexerError> {
+    ) -> Result<Token<'a>, LexerError> {
         let value = &self.source[start..start + len];
-        Ok(Token::new(value.to_string(), token_type, (start, len)))
+        Ok(Token::new(value, token_type, (start, len)))
     }
 
     fn skip_whitespace(&mut self) {
@@ -72,7 +70,7 @@ impl Lexer {
         }
     }
 
-    fn read_string(&mut self) -> Result<Token, LexerError> {
+    fn read_string(&mut self) -> Result<Token<'a>, LexerError> {
         let start = self.cursor - 1; // The opening quote has already been consumed
         while let Some(c) = self.peek() {
             if c == '"' {
@@ -95,6 +93,8 @@ impl Lexer {
 
         let value = &self.source[start + 1..self.cursor - 1];
         let len = self.cursor - start;
+        // The current implementation doesn't unescape, so we have to create a new String if there are escapes.
+        // To be safe and maintain behavior, we'll always create an owned string here.
         Ok(Token::new(
             value.to_string(),
             TokenType::String,
@@ -102,7 +102,7 @@ impl Lexer {
         ))
     }
 
-    fn read_char(&mut self) -> Result<Token, LexerError> {
+    fn read_char(&mut self) -> Result<Token<'a>, LexerError> {
         let start = self.cursor - 1; // The opening quote has already been consumed
 
         // Handle escaped char
@@ -126,7 +126,7 @@ impl Lexer {
         Ok(Token::new(value.to_string(), TokenType::Char, (start, len)))
     }
 
-    fn read_number(&mut self, start: usize) -> Result<Token, LexerError> {
+    fn read_number(&mut self, start: usize) -> Result<Token<'a>, LexerError> {
         let mut token_type = TokenType::Number;
         while let Some(c) = self.peek() {
             if c.is_ascii_digit() {
@@ -148,7 +148,7 @@ impl Lexer {
         self.make_token(token_type, start, len)
     }
 
-    fn read_identifier(&mut self, start: usize) -> Result<Token, LexerError> {
+    fn read_identifier(&mut self, start: usize) -> Result<Token<'a>, LexerError> {
         while let Some(c) = self.peek() {
             if c.is_alphanumeric() || c == '_' {
                 self.advance();
@@ -159,7 +159,7 @@ impl Lexer {
         let len = self.cursor - start;
         let value = &self.source[start..start + len];
         let token_type = lookup_identifier(value);
-        Ok(Token::new(value.to_string(), token_type, (start, len)))
+        Ok(Token::new(value, token_type, (start, len)))
     }
 }
 
@@ -208,8 +208,8 @@ fn lookup_identifier(s: &str) -> TokenType {
     KEYWORDS.get(s).cloned().unwrap_or(TokenType::Identifier)
 }
 
-impl<'a> Iterator for Lexer {
-    type Item = Result<Token, LexerError>;
+impl<'a> Iterator for Lexer<'a> {
+    type Item = Result<Token<'a>, LexerError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.skip_whitespace();
@@ -392,7 +392,7 @@ mod tests {
     #[test]
     fn basic_types() {
         let input = "i8 i16 i32 i64 u8 u16 u32 u64 usize char bool void".to_string();
-        let lexer = Lexer::new(input);
+        let lexer = Lexer::new(&input);
         let tokens: Vec<_> = lexer.collect::<Result<_, _>>().unwrap();
 
         let expected = vec![
@@ -420,7 +420,7 @@ mod tests {
     #[test]
     fn boolean_keywords() {
         let input = "true false".to_string();
-        let lexer = Lexer::new(input);
+        let lexer = Lexer::new(&input);
         let tokens: Vec<_> = lexer.collect::<Result<_, _>>().unwrap();
 
         let expected = vec![(TokenType::Boolean, "true"), (TokenType::Boolean, "false")];
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn main_keywords() {
         let input = "let fn import return struct enum typedef".to_string();
-        let lexer = Lexer::new(input);
+        let lexer = Lexer::new(&input);
         let tokens: Vec<_> = lexer.collect::<Result<_, _>>().unwrap();
 
         let expected = vec![
@@ -458,29 +458,29 @@ mod tests {
     #[test]
     fn basic_number() {
         let input = "123".to_string();
-        let mut lexer = Lexer::new(input);
+        let mut lexer = Lexer::new(&input);
         let token = lexer.next().unwrap().unwrap();
         assert_eq!(
             token,
-            Token::new("123".to_string(), TokenType::Number, (0, 3))
+            Token::new("123", TokenType::Number, (0, 3))
         );
     }
 
     #[test]
     fn float_number() {
         let input = "1.23".to_string();
-        let mut lexer = Lexer::new(input);
+        let mut lexer = Lexer::new(&input);
         let token = lexer.next().unwrap().unwrap();
         assert_eq!(
             token,
-            Token::new("1.23".to_string(), TokenType::FloatNumber, (0, 4))
+            Token::new("1.23", TokenType::FloatNumber, (0, 4))
         );
     }
 
     #[test]
     fn basic_string() {
         let input = "\"hello\"".to_string();
-        let mut lexer = Lexer::new(input);
+        let mut lexer = Lexer::new(&input);
         let token = lexer.next().unwrap().unwrap();
         assert_eq!(
             token,
@@ -491,7 +491,7 @@ mod tests {
     #[test]
     fn string_with_escapes() {
         let input = "\"hello\\\"world\"".to_string();
-        let mut lexer = Lexer::new(input);
+        let mut lexer = Lexer::new(&input);
         let token = lexer.next().unwrap().unwrap();
         assert_eq!(
             token,
@@ -502,7 +502,7 @@ mod tests {
     #[test]
     fn basic_char() {
         let input = "'a'".to_string();
-        let mut lexer = Lexer::new(input);
+        let mut lexer = Lexer::new(&input);
         let token = lexer.next().unwrap().unwrap();
         assert_eq!(token, Token::new("a".to_string(), TokenType::Char, (0, 3)));
     }
@@ -510,32 +510,32 @@ mod tests {
     #[test]
     fn operators() {
         let input = "+ - * / % = == != < > <= >= && || ! & | ^ << >>".to_string();
-        let lexer = Lexer::new(input);
+        let lexer = Lexer::new(&input);
         let tokens: Vec<_> = lexer.collect::<Result<_, _>>().unwrap();
 
         // NOTE: The original test data had incorrect values for some tokens (e.g. "%.").
         // This has been corrected to match the expected output of the lexer.
         let expected_tokens = vec![
-            Token::new("+".to_string(), TokenType::Plus, (0, 1)),
-            Token::new("-".to_string(), TokenType::Minus, (2, 1)),
-            Token::new("*".to_string(), TokenType::Multiply, (4, 1)),
-            Token::new("/".to_string(), TokenType::Divide, (6, 1)),
-            Token::new("%".to_string(), TokenType::Modulus, (8, 1)),
-            Token::new("=".to_string(), TokenType::Equal, (10, 1)),
-            Token::new("==".to_string(), TokenType::Eq, (12, 2)),
-            Token::new("!=".to_string(), TokenType::Ne, (15, 2)),
-            Token::new("<".to_string(), TokenType::Lt, (18, 1)),
-            Token::new(">".to_string(), TokenType::Bt, (20, 1)),
-            Token::new("<=".to_string(), TokenType::Leq, (22, 2)),
-            Token::new(">=".to_string(), TokenType::Beq, (25, 2)),
-            Token::new("&&".to_string(), TokenType::And, (28, 2)),
-            Token::new("||".to_string(), TokenType::Or, (31, 2)),
-            Token::new("!".to_string(), TokenType::Not, (34, 1)),
-            Token::new("&".to_string(), TokenType::Ampersand, (36, 1)),
-            Token::new("|".to_string(), TokenType::Verbar, (38, 1)),
-            Token::new("^".to_string(), TokenType::Xor, (40, 1)),
-            Token::new("<<".to_string(), TokenType::LShift, (42, 2)),
-            Token::new(">>".to_string(), TokenType::RShift, (45, 2)),
+            Token::new("+", TokenType::Plus, (0, 1)),
+            Token::new("-", TokenType::Minus, (2, 1)),
+            Token::new("*", TokenType::Multiply, (4, 1)),
+            Token::new("/", TokenType::Divide, (6, 1)),
+            Token::new("%", TokenType::Modulus, (8, 1)),
+            Token::new("=", TokenType::Equal, (10, 1)),
+            Token::new("==", TokenType::Eq, (12, 2)),
+            Token::new("!=", TokenType::Ne, (15, 2)),
+            Token::new("<", TokenType::Lt, (18, 1)),
+            Token::new(">", TokenType::Bt, (20, 1)),
+            Token::new("<=", TokenType::Leq, (22, 2)),
+            Token::new(">=", TokenType::Beq, (25, 2)),
+            Token::new("&&", TokenType::And, (28, 2)),
+            Token::new("||", TokenType::Or, (31, 2)),
+            Token::new("!", TokenType::Not, (34, 1)),
+            Token::new("&", TokenType::Ampersand, (36, 1)),
+            Token::new("|", TokenType::Verbar, (38, 1)),
+            Token::new("^", TokenType::Xor, (40, 1)),
+            Token::new("<<", TokenType::LShift, (42, 2)),
+            Token::new(">>", TokenType::RShift, (45, 2)),
         ];
 
         assert_eq!(tokens, expected_tokens);
@@ -544,7 +544,7 @@ mod tests {
     #[test]
     fn unterminated_string() {
         let input = "\"hello".to_string();
-        let mut lexer = Lexer::new(input);
+        let mut lexer = Lexer::new(&input);
         let result = lexer.next().unwrap();
         assert!(matches!(result, Err(LexerError::UnterminatedString { .. })));
     }
@@ -552,15 +552,15 @@ mod tests {
     #[test]
     fn comment() {
         let input = "// this is a comment\nlet x = 1;".to_string();
-        let lexer = Lexer::new(input);
+        let lexer = Lexer::new(&input);
         let tokens: Vec<_> = lexer.collect::<Result<_, _>>().unwrap();
 
         let expected_tokens = vec![
-            Token::new("let".to_string(), TokenType::Keyword, (21, 3)),
-            Token::new("x".to_string(), TokenType::Identifier, (25, 1)),
-            Token::new("=".to_string(), TokenType::Equal, (27, 1)),
-            Token::new("1".to_string(), TokenType::Number, (29, 1)),
-            Token::new(";".to_string(), TokenType::Semicolon, (30, 1)),
+            Token::new("let", TokenType::Keyword, (21, 3)),
+            Token::new("x", TokenType::Identifier, (25, 1)),
+            Token::new("=", TokenType::Equal, (27, 1)),
+            Token::new("1", TokenType::Number, (29, 1)),
+            Token::new(";", TokenType::Semicolon, (30, 1)),
         ];
 
         assert_eq!(tokens, expected_tokens);

--- a/genpay-lexer/src/token.rs
+++ b/genpay-lexer/src/token.rs
@@ -1,16 +1,17 @@
 use crate::token_type::TokenType;
+use std::borrow::Cow;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Token {
-    pub value: String,
+pub struct Token<'a> {
+    pub value: Cow<'a, str>,
     pub token_type: TokenType,
     pub span: (usize, usize),
 }
 
-impl Token {
-    pub fn new(value: String, token_type: TokenType, span: (usize, usize)) -> Self {
+impl<'a> Token<'a> {
+    pub fn new(value: impl Into<Cow<'a, str>>, token_type: TokenType, span: (usize, usize)) -> Self {
         Self {
-            value,
+            value: value.into(),
             token_type,
             span,
         }

--- a/genpay-parser/src/lib.rs
+++ b/genpay-parser/src/lib.rs
@@ -15,10 +15,10 @@ use miette::NamedSource;
 
 pub type Program = Vec<Statements>;
 
-pub struct Parser {
-    lexer: Lexer,
-    current_token: Token,
-    peek_token: Token,
+pub struct Parser<'a> {
+    lexer: Lexer<'a>,
+    current_token: Token<'a>,
+    peek_token: Token<'a>,
     source: NamedSource<String>,
     errors: Vec<ParserError>,
 }
@@ -44,13 +44,13 @@ enum Precedence {
 
 use genpay_lexer::token_type::TokenType;
 
-impl Parser {
-    pub fn new(source: String, filename: String) -> Self {
-        let mut lexer = Lexer::new(source.clone());
+impl<'a> Parser<'a> {
+    pub fn new(source: &'a str, filename: String) -> Self {
+        let mut lexer = Lexer::new(source);
         let current_token = match lexer.next() {
             Some(Ok(token)) => token,
             _ => Token {
-                value: "".to_string(),
+                value: "".into(),
                 token_type: TokenType::EOF,
                 span: (0, 0),
             },
@@ -58,7 +58,7 @@ impl Parser {
         let peek_token = match lexer.next() {
             Some(Ok(token)) => token,
             _ => Token {
-                value: "".to_string(),
+                value: "".into(),
                 token_type: TokenType::EOF,
                 span: (0, 0),
             },
@@ -67,7 +67,7 @@ impl Parser {
             lexer,
             current_token,
             peek_token,
-            source: NamedSource::new(filename, source),
+            source: NamedSource::new(filename, source.to_string()),
             errors: Vec::new(),
         }
     }
@@ -98,7 +98,7 @@ impl Parser {
             }
             None => {
                 self.peek_token = Token {
-                    value: "".to_string(),
+                    value: "".into(),
                     token_type: TokenType::EOF,
                     span: (0, 0),
                 };
@@ -176,7 +176,7 @@ impl Parser {
             || self.peek_token.token_type == TokenType::DivideAssign
         {
             self.next_token(); // current is now the operator
-            let operator = self.current_token.value.clone();
+            let operator = self.current_token.value.to_string();
             self.next_token(); // current is now the start of the value expression
             let value = self.parse_expression(Precedence::LOWEST)?;
             let span = (expression.get_span().0, value.get_span().1);
@@ -327,7 +327,7 @@ impl Parser {
             });
             return None;
         }
-        let binding = self.current_token.value.clone();
+        let binding = self.current_token.value.to_string();
         self.next_token();
 
         if self.current_token.token_type != TokenType::Equal {
@@ -386,7 +386,7 @@ impl Parser {
             });
             return None;
         }
-        let name = self.current_token.value.clone();
+        let name = self.current_token.value.to_string();
         self.next_token();
 
         if self.current_token.token_type != TokenType::LParen {
@@ -456,7 +456,7 @@ impl Parser {
             });
             return None;
         }
-        let name = self.current_token.value.clone();
+        let name = self.current_token.value.to_string();
         self.next_token();
 
         if self.current_token.token_type != TokenType::DoubleDots {
@@ -496,7 +496,7 @@ impl Parser {
                 });
                 return None;
             }
-            let name = self.current_token.value.clone();
+            let name = self.current_token.value.to_string();
             self.next_token();
 
             if self.current_token.token_type != TokenType::DoubleDots {
@@ -577,7 +577,7 @@ impl Parser {
             });
             return None;
         }
-        let extern_type = self.current_token.value.clone();
+        let extern_type = self.current_token.value.to_string();
         self.next_token();
 
         let public = self.current_token.token_type == TokenType::Keyword
@@ -628,7 +628,7 @@ impl Parser {
             });
             return None;
         }
-        let name = self.current_token.value.clone();
+        let name = self.current_token.value.to_string();
         self.next_token();
 
         if self.current_token.token_type != TokenType::LBrace {
@@ -656,7 +656,7 @@ impl Parser {
                     functions.entry(name.clone()).or_default().push(function);
                 }
             } else if self.current_token.token_type == TokenType::Identifier {
-                let field_name = self.current_token.value.clone();
+                let field_name = self.current_token.value.to_string();
                 self.next_token();
 
                 if self.current_token.token_type != TokenType::DoubleDots {
@@ -715,7 +715,7 @@ impl Parser {
             });
             return None;
         }
-        let name = self.current_token.value.clone();
+        let name = self.current_token.value.to_string();
         self.next_token();
 
         if self.current_token.token_type != TokenType::LBrace {
@@ -744,7 +744,7 @@ impl Parser {
                     functions.entry(name.clone()).or_default().push(function);
                 }
             } else if self.current_token.token_type == TokenType::Identifier {
-                let field_name = self.current_token.value.clone();
+                let field_name = self.current_token.value.to_string();
                 fields.push(field_name);
                 self.next_token();
             }
@@ -786,7 +786,7 @@ impl Parser {
             });
             return None;
         }
-        let identifier = self.current_token.value.clone();
+        let identifier = self.current_token.value.to_string();
         self.next_token();
 
         let mut datatype = None;
@@ -828,7 +828,7 @@ impl Parser {
             });
             return None;
         }
-        let alias = self.current_token.value.clone();
+        let alias = self.current_token.value.to_string();
         self.next_token();
 
         let datatype = self.parse_type()?;
@@ -854,7 +854,7 @@ impl Parser {
             });
             return None;
         }
-        let identifier = self.current_token.value.clone();
+        let identifier = self.current_token.value.to_string();
         self.next_token();
 
         let datatype = self.parse_type()?;
@@ -958,7 +958,7 @@ impl Parser {
 
     fn parse_string_literal(&mut self) -> Option<Expressions> {
         Some(Expressions::Value(
-            crate::value::Value::String(self.current_token.value.clone()),
+            crate::value::Value::String(self.current_token.value.to_string()),
             self.current_token.span,
         ))
     }
@@ -977,13 +977,13 @@ impl Parser {
         }
 
         Some(Expressions::Value(
-            crate::value::Value::Identifier(self.current_token.value.clone()),
+            crate::value::Value::Identifier(self.current_token.value.to_string()),
             self.current_token.span,
         ))
     }
 
     fn parse_prefix_expression(&mut self) -> Option<Expressions> {
-        let operator = self.current_token.value.clone();
+        let operator = self.current_token.value.to_string();
         let span_start = self.current_token.span.0;
 
         self.next_token();
@@ -1040,7 +1040,7 @@ impl Parser {
 
     fn parse_binary_expression(&mut self, left: Expressions) -> Option<Expressions> {
         let precedence = self.current_precedence();
-        let operator = self.current_token.value.clone();
+        let operator = self.current_token.value.to_string();
         self.next_token();
         let right = self.parse_expression(precedence)?;
 
@@ -1193,7 +1193,7 @@ impl Parser {
     }
 
     fn parse_struct_literal(&mut self) -> Option<Expressions> {
-        let name = self.current_token.value.clone();
+        let name = self.current_token.value.to_string();
         let span_start = self.current_token.span.0;
 
         self.next_token(); // consume identifier
@@ -1222,7 +1222,7 @@ impl Parser {
                 });
                 return None;
             }
-            let field_name = self.current_token.value.clone();
+            let field_name = self.current_token.value.to_string();
             self.next_token();
 
             if self.current_token.token_type != TokenType::Equal {
@@ -1381,7 +1381,7 @@ impl Parser {
                 Some(Type::Pointer(Box::new(inner_type)))
             }
             TokenType::Type => {
-                let type_name = self.current_token.value.clone();
+                let type_name = self.current_token.value.to_string();
                 self.next_token();
                 match type_name.as_str() {
                     "i8" => Some(Type::I8),
@@ -1402,7 +1402,7 @@ impl Parser {
                 }
             }
             TokenType::Identifier => {
-                let alias = self.current_token.value.clone();
+                let alias = self.current_token.value.to_string();
                 self.next_token();
                 Some(Type::Alias(alias))
             }
@@ -1509,7 +1509,7 @@ mod tests {
     #[test]
     fn test_let_statement() {
         let input = "let x = 5;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1533,7 +1533,7 @@ mod tests {
     #[test]
     fn test_return_statement() {
         let input = "return 5;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1553,7 +1553,7 @@ mod tests {
     #[test]
     fn test_infix_expression() {
         let input = "5 + 5;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1582,7 +1582,7 @@ mod tests {
     #[test]
     fn test_operator_precedence() {
         let input = "-a * b".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
         assert_eq!(program.len(), 1);
         let statement = &program[0];
@@ -1610,7 +1610,7 @@ mod tests {
     #[test]
     fn test_function_call_expression() {
         let input = "add(1, 2 * 3, 4 + 5);".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
         assert_eq!(program.len(), 1);
         let statement = &program[0];
@@ -1670,7 +1670,7 @@ mod tests {
     #[test]
     fn test_fn_definition() {
         let input = "fn add(a: i32, b: i32) i32 { return a + b; }".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1700,7 +1700,7 @@ mod tests {
     #[test]
     fn test_array_literal() {
         let input = "[1, 2 * 2, 3 + 3]".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1716,7 +1716,7 @@ mod tests {
     #[test]
     fn test_slice_expression() {
         let input = "myArray[1 + 1]".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1742,7 +1742,7 @@ mod tests {
     #[test]
     fn test_struct_literal() {
         let input = "MyStruct { .a = 1, .b = 2 }".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1759,7 +1759,7 @@ mod tests {
     #[test]
     fn test_if_else_statement() {
         let input = "if (x < y) { x } else { y }".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1788,7 +1788,7 @@ mod tests {
     #[test]
     fn test_while_statement() {
         let input = "while (x < y) { x = x + 1 }".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1812,7 +1812,7 @@ mod tests {
     #[test]
     fn test_for_statement() {
         let input = "for i = 0 { x }".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1840,7 +1840,7 @@ mod tests {
     #[test]
     fn test_struct_definition() {
         let input = "struct Point { x: i32, y: i32 }".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1857,7 +1857,7 @@ mod tests {
     #[test]
     fn test_enum_definition() {
         let input = "enum Color { Red, Green, Blue }".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1874,7 +1874,7 @@ mod tests {
     #[test]
     fn test_binary_assign_statement() {
         let input = "x += 5;".to_string();
-        let mut parser = Parser::new(input.to_string(), "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1908,7 +1908,7 @@ mod tests {
     #[test]
     fn test_assign_statement() {
         let input = "x = 5;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1934,7 +1934,7 @@ mod tests {
     #[test]
     fn test_typedef_statement() {
         let input = "typedef my_int i32;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1958,7 +1958,7 @@ mod tests {
     #[test]
     fn test_extern_declare_statement() {
         let input = "_extern_declare my_var i32;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -1984,7 +1984,7 @@ mod tests {
     #[test]
     fn test_link_c_statement() {
         let input = "_link_c \"mylib.a\";".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -2004,7 +2004,7 @@ mod tests {
     #[test]
     fn test_break_statement() {
         let input = "break;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
 
         assert_eq!(program.len(), 1);
@@ -2021,7 +2021,7 @@ mod tests {
     fn test_pointer_related_parsing() {
         // Test let statement with pointer type
         let input = "let x: *i32 = &y;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
         assert_eq!(program.len(), 1);
         let statement = &program[0];
@@ -2044,7 +2044,7 @@ mod tests {
 
         // Test dereference expression
         let input = "*x;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
         assert_eq!(program.len(), 1);
         let statement = &program[0];
@@ -2055,7 +2055,7 @@ mod tests {
 
         // Test reference expression
         let input = "&y;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
         assert_eq!(program.len(), 1);
         let statement = &program[0];
@@ -2066,7 +2066,8 @@ mod tests {
 
         // Test assignment to dereferenced pointer
         let input = "*x = 10;".to_string();
-        let mut parser = Parser::new(input.to_string(), "test.pay".to_string());
+        let s = input.to_string();
+        let mut parser = Parser::new(&s, "test.pay".to_string());
         let program = parser.parse().unwrap();
         assert_eq!(program.len(), 1);
         let statement = &program[0];
@@ -2086,7 +2087,7 @@ mod tests {
 
         // Test function with pointer argument and return type
         let input = "fn foo(p: *i32) *i32 { return p; }".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
         assert_eq!(program.len(), 1);
         let statement = &program[0];
@@ -2107,7 +2108,7 @@ mod tests {
 
         // Test let statement with double pointer type
         let input = "let x: **i32;".to_string();
-        let mut parser = Parser::new(input, "test.pay".to_string());
+        let mut parser = Parser::new(&input, "test.pay".to_string());
         let program = parser.parse().unwrap();
         assert_eq!(program.len(), 1);
         let statement = &program[0];

--- a/genpay/src/main.rs
+++ b/genpay/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
     cli::info("Parsing", "syntax tree");
 
     // Syntax Analyzer initialization.
-    let mut parser = genpay_parser::Parser::new(src.clone(), fname.to_string());
+    let mut parser = genpay_parser::Parser::new(&src, fname.to_string());
     let ast = match parser.parse() {
         Ok(ast) => ast,
         Err(errors) => {


### PR DESCRIPTION
This commit refactors the `genpay-lexer` and `genpay-parser` crates to use `Cow<'a, str>` for token values instead of `String`. This is a performance optimization that avoids unnecessary string allocations for tokens that can be represented as slices of the source code.

The following changes were made:
- The `Token` struct in `genpay-lexer` is now generic over a lifetime `'a` and its `value` field is a `Cow<'a, str>`.
- The `Lexer` in `genpay-lexer` is now generic over a lifetime `'a` and operates on a string slice `&'a str`.
- The `Parser` in `genpay-parser` is now generic over a lifetime `'a` and its internal tokens are `Token<'a>`.
- The `Parser::new` function now accepts a string slice `&'a str`.
- The main binary in `genpay` has been updated to correctly instantiate the new `Parser`.
- All tests have been updated to reflect these changes.